### PR TITLE
[Vibe] implement expansion workflow for nl blocks

### DIFF
--- a/Source/DafnyCore.Test/NaturalLanguageBlocksOptionTest.cs
+++ b/Source/DafnyCore.Test/NaturalLanguageBlocksOptionTest.cs
@@ -27,4 +27,19 @@ public class NaturalLanguageBlocksOptionTest {
     var parserOptionResult = ParseParserOptions("--natural-language-blocks");
     Assert.True(parserOptionResult.GetValueForOption(CommonOptionBag.NaturalLanguageBlocks));
   }
+
+  [Fact]
+  public void NaturalLanguageIntermediateProductsDirectory_DefaultOff() {
+    Assert.Contains(DafnyCommands.ParserOptions,
+      option => option == CommonOptionBag.NaturalLanguageIntermediateProductsDirectory);
+
+    var parserOptionResult = ParseParserOptions();
+    Assert.Null(parserOptionResult.GetValueForOption(CommonOptionBag.NaturalLanguageIntermediateProductsDirectory));
+  }
+
+  [Fact]
+  public void NaturalLanguageIntermediateProductsDirectory_OptionOn() {
+    var parserOptionResult = ParseParserOptions("--natural-language-intermediate-products-directory", "out/nl-intermediates");
+    Assert.Equal("out/nl-intermediates", parserOptionResult.GetValueForOption(CommonOptionBag.NaturalLanguageIntermediateProductsDirectory)?.ToString());
+  }
 }

--- a/Source/DafnyCore.Test/NaturalLanguageResolverTest.cs
+++ b/Source/DafnyCore.Test/NaturalLanguageResolverTest.cs
@@ -9,9 +9,6 @@ namespace DafnyCore.Test;
 
 public class NaturalLanguageResolverTest {
   private const string FullFilePath = "untitled:NaturalLanguageResolverTest";
-  private const string UnsupportedNaturalLanguageBlocksDiagnostic =
-    "Natural-language blocks are parsed experimentally, but semantics are not supported yet";
-
   private static async Task<(Program Program, BatchErrorReporter Reporter)> ParseAndResolve(string dafnyProgramText,
     DafnyOptions options) {
     var rootUri = new Uri(FullFilePath);
@@ -44,7 +41,7 @@ public class NaturalLanguageResolverTest {
   [Theory]
   [InlineData(false)]
   [InlineData(true)]
-  public async Task NaturalLanguageBlocks_ReportDeterministicResolverDiagnostics_InLegacyAndPreType(bool typeSystemRefresh) {
+  public async Task NaturalLanguageBlocks_DoNotReportPlaceholderWarnings_InLegacyAndPreType(bool typeSystemRefresh) {
     var options = new DafnyOptions(DafnyOptions.Default);
     options.ApplyDefaultOptionsWithoutSettingsDefault();
     options.Set(CommonOptionBag.NaturalLanguageBlocks, true);
@@ -60,11 +57,10 @@ method UsesNaturalLanguageBlocks() {
     var diagnostics = reporter.AllMessages
       .Where(message => message.Level == ErrorLevel.Warning)
       .Where(message => message.Source == MessageSource.Resolver)
-      .Where(message => message.Message.Contains(UnsupportedNaturalLanguageBlocksDiagnostic))
       .ToList();
 
     Assert.Equal(0, reporter.ErrorCount);
-    Assert.Equal(2, diagnostics.Count);
+    Assert.Empty(diagnostics);
   }
 
   [Theory]

--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -332,6 +332,12 @@ true - Print debug information for the new type system.".TrimStart()) {
     "(experimental) Enable parser support for natural-language blocks.") {
     IsHidden = true
   };
+  public static readonly Option<DirectoryInfo> NaturalLanguageIntermediateProductsDirectory =
+    new("--natural-language-intermediate-products-directory",
+      "(experimental) Directory where natural-language intermediate artifacts are emitted.") {
+      ArgumentHelpName = "directory",
+      IsHidden = true
+    };
   public static readonly Option<bool> SpillTranslation = new("--spill-translation",
     @"In case the Dafny source code is translated to another language, emit that translation.") {
   };
@@ -702,6 +708,7 @@ NoGhost - disable printing of functions, ghost methods, and proof
     OptionRegistry.RegisterGlobalOption(UseStandardLibraries, OptionCompatibility.OptionLibraryImpliesLocalError);
     OptionRegistry.RegisterGlobalOption(Referrers, OptionCompatibility.CheckOptionMatches);
     OptionRegistry.RegisterGlobalOption(NaturalLanguageBlocks, OptionCompatibility.CheckOptionMatches);
+    OptionRegistry.RegisterOption(NaturalLanguageIntermediateProductsDirectory, OptionScope.Cli);
     OptionRegistry.RegisterOption(TranslateStandardLibrary, OptionScope.Cli);
     OptionRegistry.RegisterOption(WarnAsErrors, OptionScope.Cli);
     OptionRegistry.RegisterOption(SuppressWarnings, OptionScope.Cli);

--- a/Source/DafnyCore/Options/DafnyCommands.cs
+++ b/Source/DafnyCore/Options/DafnyCommands.cs
@@ -116,7 +116,8 @@ public static class DafnyCommands {
     CommonOptionBag.LogLocation,
     CommonOptionBag.CheckSourceLocationConsistency,
     CommonOptionBag.Referrers,
-    CommonOptionBag.NaturalLanguageBlocks
+    CommonOptionBag.NaturalLanguageBlocks,
+    CommonOptionBag.NaturalLanguageIntermediateProductsDirectory
   });
 
   public static IReadOnlyList<Option> ResolverOptions = new List<Option>(new Option[] {

--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
@@ -21,9 +21,6 @@ using Microsoft.Dafny.Plugins;
 
 namespace Microsoft.Dafny {
   public partial class ModuleResolver {
-    private const string UnsupportedNaturalLanguageBlocksDiagnostic =
-      "Natural-language blocks are parsed experimentally, but semantics are not supported yet";
-
     public List<LabeledStatement> loopStack = [];  // the enclosing loops (from which it is possible to break out)
     public Scope<Label>/*!*/ DominatingStatementLabels { get; private set; }
 
@@ -1278,7 +1275,6 @@ namespace Microsoft.Dafny {
 
         decreasesToExpr.Type = Type.Bool;
       } else if (expr is NaturalLanguageExpression naturalLanguageExpression) {
-        reporter.Warning(MessageSource.Resolver, ParseErrors.ErrorId.none, naturalLanguageExpression.Origin, UnsupportedNaturalLanguageBlocksDiagnostic);
         naturalLanguageExpression.Type = new InferredTypeProxy();
       } else if (expr is FieldLocationExpression or IndexFieldLocationExpression or FieldLocation or IndexFieldLocation) {
         reporter.Error(MessageSource.Resolver, expr,
@@ -3778,9 +3774,8 @@ namespace Microsoft.Dafny {
         var s = (PrintStmt)stmt;
         s.Args.ForEach(e => ResolveExpression(e, resolutionContext));
 
-      } else if (stmt is NaturalLanguageStatement naturalLanguageStatement) {
+      } else if (stmt is NaturalLanguageStatement) {
         // TODO(nl-semantics): replace placeholder behavior when NL semantics are defined
-        reporter.Warning(MessageSource.Resolver, ParseErrors.ErrorId.none, naturalLanguageStatement.Origin, UnsupportedNaturalLanguageBlocksDiagnostic);
 
       } else if (stmt is HideRevealStmt hideRevealStmt) {
         stmt.GenResolve(this, resolutionContext);

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
@@ -18,9 +18,6 @@ using ResolutionContext = Microsoft.Dafny.ResolutionContext;
 namespace Microsoft.Dafny {
   public partial class PreTypeResolver {
     // ---------------------------------------- Expressions ----------------------------------------
-    private const string UnsupportedNaturalLanguageBlocksDiagnostic =
-      "Natural-language blocks are parsed experimentally, but semantics are not supported yet";
-
     public void ResolveExpression(Expression expr, ResolutionContext resolutionContext) {
       Contract.Requires(expr != null);
       Contract.Requires(resolutionContext != null);
@@ -833,7 +830,6 @@ namespace Microsoft.Dafny {
             break;
           }
         case NaturalLanguageExpression naturalLanguageExpression: {
-            ReportWarning(naturalLanguageExpression.Origin, UnsupportedNaturalLanguageBlocksDiagnostic);
             naturalLanguageExpression.PreType = CreatePreTypeProxy("natural-language expression");
             break;
           }

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Statements.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Statements.cs
@@ -114,9 +114,8 @@ namespace Microsoft.Dafny {
           ResolveExpression(e, resolutionContext);
         }
 
-      } else if (stmt is NaturalLanguageStatement naturalLanguageStatement) {
+      } else if (stmt is NaturalLanguageStatement) {
         // TODO(nl-semantics): replace placeholder behavior when NL semantics are defined
-        ReportWarning(naturalLanguageStatement.Origin, UnsupportedNaturalLanguageBlocksDiagnostic);
 
       } else if (stmt is BreakOrContinueStmt) {
         var s = (BreakOrContinueStmt)stmt;

--- a/Source/DafnyDriver/Commands/VerifyCommand.cs
+++ b/Source/DafnyDriver/Commands/VerifyCommand.cs
@@ -60,6 +60,11 @@ public static class VerifyCommand {
       options.TrackVerificationCoverage = true;
     }
 
+    var preparationExitValue = await SynchronousCliCompilation.PrepareOptionsForCliCompilationAsync(options);
+    if (preparationExitValue != ExitValue.SUCCESS) {
+      return (int)preparationExitValue;
+    }
+
     var compilation = CliCompilation.Create(options);
     compilation.Start();
 

--- a/Source/DafnyDriver/Legacy/SynchronousCliCompilation.cs
+++ b/Source/DafnyDriver/Legacy/SynchronousCliCompilation.cs
@@ -12,6 +12,10 @@
 
 using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Net.Http;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System;
@@ -26,6 +30,7 @@ using System.Diagnostics;
 using Microsoft.Dafny.Compilers;
 using Microsoft.Dafny.Plugins;
 using VC;
+using DafnyCore;
 
 namespace Microsoft.Dafny {
 
@@ -37,6 +42,15 @@ namespace Microsoft.Dafny {
   /// </summary>
   public class SynchronousCliCompilation : IDisposable {
     private readonly ExecutionEngine engine;
+    private static readonly HttpClient NaturalLanguageHttpClient = new();
+    private static readonly JsonSerializerOptions NaturalLanguageRequestJsonOptions = new() {
+      PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+      DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+      WriteIndented = true
+    };
+    private static readonly JsonSerializerOptions NaturalLanguageResponseJsonOptions = new() {
+      PropertyNameCaseInsensitive = true
+    };
 
     public SynchronousCliCompilation(DafnyOptions dafnyOptions) {
       engine = ExecutionEngine.CreateWithoutSharedCache(dafnyOptions);
@@ -76,6 +90,132 @@ namespace Microsoft.Dafny {
       }
 
       return (int)exitValue;
+    }
+
+    public static async Task<(ExitValue ExitValue,
+      List<DafnyFile> DafnyFiles,
+      List<string> OtherFiles)> GetPreparedDafnyFiles(DafnyOptions options) {
+      var preparation = await PrepareDafnyFilesAsync(options);
+      return (preparation.ExitValue, preparation.PreparedFiles, preparation.OtherFiles);
+    }
+
+    public static async Task<ExitValue> PrepareOptionsForCliCompilationAsync(DafnyOptions options) {
+      if (!options.Get(CommonOptionBag.NaturalLanguageBlocks)) {
+        return ExitValue.SUCCESS;
+      }
+
+      var originalRootUris = CollectExplicitRootSourceUris(options);
+      var preparation = await PrepareDafnyFilesAsync(options);
+      if (preparation.ExitValue != ExitValue.SUCCESS) {
+        return preparation.ExitValue;
+      }
+
+      ReplaceCliCompilationInputs(options, originalRootUris, preparation.OriginalFiles, preparation.PreparedFiles);
+      return ExitValue.SUCCESS;
+    }
+
+    private static async Task<(ExitValue ExitValue,
+      List<DafnyFile> OriginalFiles,
+      List<DafnyFile> PreparedFiles,
+      List<string> OtherFiles)> PrepareDafnyFilesAsync(DafnyOptions options) {
+      var backend = GetBackend(options);
+      if (backend == null) {
+        return (ExitValue.PREPROCESSING_ERROR, [], [], []);
+      }
+      options.Backend = backend;
+
+      if (options.Get(CommonOptionBag.NaturalLanguageBlocks) && options.AllowSourceFolders) {
+        ExpandFolderSourceUrisIntoFiles(options);
+      }
+
+      var (getFilesExitCode, dafnyFiles, otherFiles) = await GetDafnyFiles(options);
+      if (getFilesExitCode != ExitValue.SUCCESS || !options.Get(CommonOptionBag.NaturalLanguageBlocks)) {
+        return (getFilesExitCode, dafnyFiles, dafnyFiles, otherFiles);
+      }
+
+      using var driver = new SynchronousCliCompilation(options);
+      var naturalLanguageExpansion = await driver.ExpandNaturalLanguageBlocksAsync(dafnyFiles, options);
+      if (!naturalLanguageExpansion.Success) {
+        return (naturalLanguageExpansion.ExitValue, dafnyFiles, [], otherFiles);
+      }
+
+      return (ExitValue.SUCCESS, dafnyFiles, naturalLanguageExpansion.RewrittenFiles.ToList(), otherFiles);
+    }
+
+    private static HashSet<Uri> CollectExplicitRootSourceUris(DafnyOptions options) {
+      var result = new HashSet<Uri>();
+      foreach (var uri in options.CliRootSourceUris.Where(uri => uri.IsFile)) {
+        result.Add(uri);
+      }
+
+      if (options.DafnyProject != null) {
+        foreach (var uri in options.DafnyProject.GetRootSourceUris(OnDiskFileSystem.Instance)) {
+          result.Add(uri);
+        }
+      }
+
+      return result;
+    }
+
+    private static void ExpandFolderSourceUrisIntoFiles(DafnyOptions options) {
+      var expandedUris = new List<Uri>();
+      var seenPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+      foreach (var uri in options.CliRootSourceUris) {
+        if (!uri.IsFile) {
+          expandedUris.Add(uri);
+          continue;
+        }
+
+        var path = uri.LocalPath;
+        if (!Directory.Exists(path)) {
+          if (seenPaths.Add(path)) {
+            expandedUris.Add(uri);
+          }
+          continue;
+        }
+
+        foreach (var filePath in Directory.GetFiles(path, "*.dfy", SearchOption.AllDirectories).OrderBy(filePath => filePath, StringComparer.OrdinalIgnoreCase)) {
+          var fullPath = Path.GetFullPath(filePath);
+          if (seenPaths.Add(fullPath)) {
+            expandedUris.Add(new Uri(fullPath));
+          }
+        }
+      }
+
+      options.CliRootSourceUris.Clear();
+      foreach (var uri in expandedUris) {
+        options.CliRootSourceUris.Add(uri);
+      }
+      options.SourceFolders.Clear();
+    }
+
+    private static void ReplaceCliCompilationInputs(
+      DafnyOptions options,
+      ISet<Uri> originalRootUris,
+      IReadOnlyList<DafnyFile> originalFiles,
+      IReadOnlyList<DafnyFile> preparedFiles) {
+      var preparedRootUris = new List<Uri>();
+      for (var index = 0; index < originalFiles.Count && index < preparedFiles.Count; index++) {
+        var originalFile = originalFiles[index];
+        if (!originalRootUris.Contains(originalFile.Uri)) {
+          continue;
+        }
+
+        var preparedFile = preparedFiles[index];
+        if (preparedFile.Uri.IsFile) {
+          preparedRootUris.Add(preparedFile.Uri);
+        }
+      }
+
+      options.CliRootSourceUris.Clear();
+      foreach (var uri in preparedRootUris.Distinct()) {
+        options.CliRootSourceUris.Add(uri);
+      }
+
+      var projectUri = options.CliRootSourceUris.FirstOrDefault() ?? options.DafnyProject?.Uri ?? new Uri(Directory.GetCurrentDirectory());
+      options.DafnyProject = new DafnyProject(null, projectUri, null, new HashSet<string>(), new HashSet<string>(), new Dictionary<string, object>()) {
+        ImplicitFromCli = true
+      };
     }
 
     public static async Task<(ExitValue ExitValue,
@@ -288,6 +428,15 @@ namespace Microsoft.Dafny {
         return exitValue;
       }
 
+      if (options.Get(CommonOptionBag.NaturalLanguageBlocks)) {
+        var naturalLanguageExpansion = await ExpandNaturalLanguageBlocksAsync(dafnyFiles, options);
+        if (!naturalLanguageExpansion.Success) {
+          return naturalLanguageExpansion.ExitValue;
+        }
+        dafnyFiles = naturalLanguageExpansion.RewrittenFiles;
+        dafnyFileNames = DafnyFile.FileNames(dafnyFiles);
+      }
+
       string programName = dafnyFileNames.Count == 1 ? dafnyFileNames[0] : "the_program";
       var (dafnyProgram, err) = await DafnyMain.ParseCheck(options.Input, dafnyFiles, programName, options);
       if (err != null) {
@@ -367,6 +516,1747 @@ namespace Microsoft.Dafny {
       return exitValue;
     }
 
+    private async Task<(bool Success, ExitValue ExitValue, IReadOnlyList<DafnyFile> RewrittenFiles)> ExpandNaturalLanguageBlocksAsync(
+      IReadOnlyList<DafnyFile> originalFiles, DafnyOptions options) {
+      if (options.UseStdin) {
+        await options.OutputWriter.Status("*** Error: --natural-language-blocks does not support stdin input.");
+        return (false, ExitValue.PREPROCESSING_ERROR, originalFiles);
+      }
+
+      var originalFileNames = DafnyFile.FileNames(originalFiles);
+      var parseProgramName = originalFileNames.Count == 1 ? originalFileNames[0] : "the_program";
+      var (parsedProgram, parseErr) = await DafnyMain.Parse(originalFiles, parseProgramName, options);
+      if (parseErr != null || parsedProgram == null) {
+        await options.OutputWriter.Status(parseErr ?? "Failed to parse program for natural-language expansion.");
+        return (false, ExitValue.DAFNY_ERROR, originalFiles);
+      }
+      var resolveErr = DafnyMain.Resolve(parsedProgram);
+
+      var sourceTexts = LoadSourceTextsForRootFiles(originalFiles, options);
+      var tasks = BuildNaturalLanguageTasks(parsedProgram, sourceTexts);
+      if (tasks.Count == 0) {
+        return (true, ExitValue.SUCCESS, originalFiles);
+      }
+
+      var intermediateProductsDirectory = options.Get(CommonOptionBag.NaturalLanguageIntermediateProductsDirectory);
+      var emitIntermediateProducts = intermediateProductsDirectory != null;
+
+      var firstRootFile = originalFiles.FirstOrDefault(file => file.Uri.IsFile && file.Extension == DafnyFile.DafnyFileExtension);
+      var sourceDirectory = firstRootFile == null
+        ? Directory.GetCurrentDirectory()
+        : Path.GetDirectoryName(firstRootFile.Uri.LocalPath) ?? Directory.GetCurrentDirectory();
+      var exchangeDirectory = intermediateProductsDirectory == null
+        ? sourceDirectory
+        : Path.GetFullPath(intermediateProductsDirectory.FullName);
+      if (emitIntermediateProducts) {
+        Directory.CreateDirectory(exchangeDirectory);
+      }
+
+      var exchangeBase = Path.Combine(exchangeDirectory, $"{Path.GetFileNameWithoutExtension(parsedProgram.Name)}.nlgen");
+      var supportDeclarations = CollectRelevantSupportDeclarations(parsedProgram, sourceTexts);
+      var feedback = CollectFeedbackByTask(parsedProgram, resolveErr, tasks);
+      var taskStates = tasks.ToDictionary(task => task.TaskId, task => new NaturalLanguageTaskState());
+
+      for (var attempt = 1; attempt <= 10; attempt++) {
+        var apiUrl = Environment.GetEnvironmentVariable("DAFNY_NL_API_URL");
+        var tasksToRequest = SelectTasksToRequest(attempt, tasks, feedback, taskStates);
+        var taskRequestResults = tasksToRequest.Count == 0
+          ? []
+          : await Task.WhenAll(tasksToRequest.Select(task =>
+            SendNaturalLanguageTaskRequestAsync(
+              apiUrl,
+              parsedProgram,
+              task,
+              taskStates[task.TaskId],
+              supportDeclarations,
+              attempt,
+              emitIntermediateProducts,
+              exchangeBase)));
+
+        foreach (var taskRequestResult in taskRequestResults) {
+          if (!taskRequestResult.Success) {
+            await options.OutputWriter.Status(taskRequestResult.ErrorMessage);
+            if (!emitIntermediateProducts && taskRequestResult.ErrorMessage.Contains("expected natural-language response file not found")) {
+              await options.OutputWriter.Status(
+                "*** Hint: pass --natural-language-intermediate-products-directory <directory> to emit NL task/response JSON files.");
+            }
+            return (false, ExitValue.DAFNY_ERROR, originalFiles);
+          }
+        }
+
+        foreach (var taskRequestResult in taskRequestResults) {
+          taskStates[taskRequestResult.Response.TaskId].CurrentResponse = taskRequestResult.Response;
+          if (!string.IsNullOrWhiteSpace(taskRequestResult.OpenAiResponseId)) {
+            taskStates[taskRequestResult.Response.TaskId].PreviousOpenAiResponseId = taskRequestResult.OpenAiResponseId;
+          }
+        }
+
+        if (!TryBuildNaturalLanguageResponseFile(tasks, taskStates, out var response, out var responseError)) {
+          await options.OutputWriter.Status($"*** Error: invalid NL response file: {responseError}");
+          return (false, ExitValue.DAFNY_ERROR, originalFiles);
+        }
+
+        if (!TryApplyNaturalLanguageResponses(tasks, sourceTexts, response, out var rewrittenSources,
+              out var appliedTaskContexts, out var applyError)) {
+          await options.OutputWriter.Status($"*** Error: invalid NL response file: {applyError}");
+          return (false, ExitValue.DAFNY_ERROR, originalFiles);
+        }
+
+        Dictionary<Uri, string> attemptPaths;
+        string temporaryAttemptDirectory = null;
+        if (emitIntermediateProducts) {
+          attemptPaths = WriteRewrittenSources(originalFiles, rewrittenSources,
+            suffix: $".nlgen.attempt{attempt}", outputDirectoryOverride: exchangeDirectory);
+        } else {
+          temporaryAttemptDirectory = Path.Combine(Path.GetTempPath(), $"dafny-nlgen-{Guid.NewGuid():N}");
+          Directory.CreateDirectory(temporaryAttemptDirectory);
+          attemptPaths = WriteRewrittenSources(originalFiles, rewrittenSources,
+            suffix: $".nlgen.attempt{attempt}", outputDirectoryOverride: temporaryAttemptDirectory);
+        }
+
+        var attemptFiles = CreateDafnyFilesFromPaths(originalFiles, attemptPaths, options);
+        var attemptSourcePathMap = BuildNaturalLanguageSourcePathMap(attemptPaths);
+
+        (bool Verified, Program Program, NaturalLanguageFeedbackByTask Feedback) verification;
+        try {
+          verification = await VerifyCandidateFilesAsync(attemptFiles, options, tasks, attemptSourcePathMap);
+        }
+        finally {
+          if (temporaryAttemptDirectory != null) {
+            TryDeleteDirectory(temporaryAttemptDirectory);
+          }
+        }
+
+        if (verification.Verified) {
+          var finalPaths = WriteRewrittenSources(originalFiles, rewrittenSources, suffix: ".nlgen");
+          var finalFiles = CreateDafnyFilesFromPaths(originalFiles, finalPaths, options);
+          await options.OutputWriter.Status(
+            $"Natural-language expansion completed after {attempt} attempt(s). Rewritten sources were saved with '.nlgen.dfy' suffix.");
+          return (true, ExitValue.SUCCESS, finalFiles);
+        }
+
+        feedback = verification.Feedback;
+        RecordRetryHistory(attempt, feedback, tasks, taskStates, appliedTaskContexts);
+      }
+
+      await options.OutputWriter.Status("*** Error: natural-language expansion exceeded retry limit (10 attempts).");
+      return (false, ExitValue.VERIFICATION_ERROR, originalFiles);
+    }
+
+    private static async Task<string> CallNaturalLanguageApiAsync(Uri apiUri, bool attachOpenAiApiKey, string requestJson) {
+      using var request = new HttpRequestMessage(HttpMethod.Post, apiUri) {
+        Content = new StringContent(requestJson, Encoding.UTF8, "application/json")
+      };
+      request.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
+
+      if (attachOpenAiApiKey) {
+        var openAiApiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+        if (string.IsNullOrWhiteSpace(openAiApiKey)) {
+          throw new Exception("OPENAI_API_KEY is required when sending NL requests to the OpenAI Responses API.");
+        }
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", openAiApiKey);
+      }
+
+      using var response = await NaturalLanguageHttpClient.SendAsync(request);
+      var responseBody = await response.Content.ReadAsStringAsync();
+      if (!response.IsSuccessStatusCode) {
+        throw new Exception($"NL API returned {(int)response.StatusCode}: {responseBody}");
+      }
+
+      return responseBody;
+    }
+
+    private static (Uri ApiUri, bool AttachOpenAiApiKey)? ResolveNaturalLanguageApiEndpoint(string configuredApiUrl) {
+      var openAiApiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+      var hasOpenAiApiKey = !string.IsNullOrWhiteSpace(openAiApiKey);
+      var effectiveApiUrl = !string.IsNullOrWhiteSpace(configuredApiUrl)
+        ? configuredApiUrl!
+        : (hasOpenAiApiKey ? "https://api.openai.com/v1/responses" : null);
+      if (string.IsNullOrWhiteSpace(effectiveApiUrl)) {
+        return null;
+      }
+
+      if (!Uri.TryCreate(effectiveApiUrl, UriKind.Absolute, out var apiUri)) {
+        throw new Exception($"Invalid natural-language API URL: {effectiveApiUrl}");
+      }
+
+      var isLoopback = apiUri.IsLoopback;
+      if (!string.Equals(apiUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) && !isLoopback) {
+        throw new Exception($"Refusing to send natural-language requests over insecure transport to '{apiUri}'. Use HTTPS or a loopback URL for local testing.");
+      }
+
+      var isOfficialOpenAiEndpoint =
+        string.Equals(apiUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(apiUri.Host, "api.openai.com", StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(apiUri.AbsolutePath, "/v1/responses", StringComparison.Ordinal);
+
+      if (hasOpenAiApiKey && !isOfficialOpenAiEndpoint && !isLoopback) {
+        throw new Exception($"Refusing to send OPENAI_API_KEY to non-OpenAI endpoint '{apiUri}'. Clear DAFNY_NL_API_URL or use the official OpenAI Responses API URL.");
+      }
+
+      return (apiUri, isOfficialOpenAiEndpoint);
+    }
+
+    private static async Task<NaturalLanguageTaskRequestResult> SendNaturalLanguageTaskRequestAsync(
+      string apiUrl,
+      Program program,
+      NaturalLanguageTask task,
+      NaturalLanguageTaskState taskState,
+      IReadOnlyList<NaturalLanguageSupportDeclaration> supportDeclarations,
+      int attempt,
+      bool emitIntermediateProducts,
+      string exchangeBase) {
+      var apiEndpoint = ResolveNaturalLanguageApiEndpoint(apiUrl);
+      var prompt = BuildNaturalLanguagePrompt(task, supportDeclarations, taskState.RetryHistory);
+      var request = CreateOpenAiResponsesRequest(program.Name, task, prompt, attempt,
+        apiEndpoint?.AttachOpenAiApiKey == true ? taskState.PreviousOpenAiResponseId : null);
+
+      var requestJson = JsonSerializer.Serialize(request, NaturalLanguageRequestJsonOptions);
+      var taskPathSuffix = SanitizeForPath(task.CallableName);
+      var requestPath = $"{exchangeBase}.task.{taskPathSuffix}.attempt{attempt}.json";
+      if (emitIntermediateProducts) {
+        var promptPath = $"{exchangeBase}.prompt.{taskPathSuffix}.attempt{attempt}.txt";
+        await File.WriteAllTextAsync(promptPath, prompt, Encoding.UTF8);
+        await File.WriteAllTextAsync(requestPath, requestJson);
+      }
+
+      var responsePath = $"{exchangeBase}.response.{taskPathSuffix}.attempt{attempt}.json";
+      var responseSourceLabel = responsePath;
+      string responseJson;
+      if (apiEndpoint != null) {
+        responseJson = await CallNaturalLanguageApiAsync(apiEndpoint.Value.ApiUri, apiEndpoint.Value.AttachOpenAiApiKey, requestJson);
+        responseSourceLabel = "NL API response";
+        if (emitIntermediateProducts) {
+          await File.WriteAllTextAsync(responsePath, responseJson);
+          responseSourceLabel = responsePath;
+        }
+      } else {
+        if (!File.Exists(responsePath)) {
+          return new NaturalLanguageTaskRequestResult {
+            Success = false,
+            ErrorMessage = $"*** Error: expected natural-language response file not found: {responsePath}"
+          };
+        }
+        responseJson = await File.ReadAllTextAsync(responsePath);
+      }
+
+      OpenAiResponsesApiResponse openAiResponse;
+      try {
+        openAiResponse = JsonSerializer.Deserialize<OpenAiResponsesApiResponse>(responseJson, NaturalLanguageResponseJsonOptions)
+                         ?? new OpenAiResponsesApiResponse();
+      } catch (Exception e) {
+        return new NaturalLanguageTaskRequestResult {
+          Success = false,
+          ErrorMessage = $"*** Error: could not read NL response file '{responseSourceLabel}': {e.Message}"
+        };
+      }
+
+      var structuredText = ExtractStructuredOutputText(openAiResponse, out var refusalText);
+      if (!string.IsNullOrWhiteSpace(refusalText)) {
+        return new NaturalLanguageTaskRequestResult {
+          Success = false,
+          ErrorMessage = $"*** Error: NL API refused task '{task.TaskId}': {refusalText}"
+        };
+      }
+      if (string.IsNullOrWhiteSpace(structuredText)) {
+        return new NaturalLanguageTaskRequestResult {
+          Success = false,
+          ErrorMessage = $"*** Error: NL API response did not contain structured output text for task '{task.TaskId}'."
+        };
+      }
+
+      NaturalLanguageTaskResponsePayload taskResponsePayload;
+      try {
+        taskResponsePayload = JsonSerializer.Deserialize<NaturalLanguageTaskResponsePayload>(structuredText, NaturalLanguageResponseJsonOptions)
+                              ?? new NaturalLanguageTaskResponsePayload();
+      } catch (Exception e) {
+        return new NaturalLanguageTaskRequestResult {
+          Success = false,
+          ErrorMessage = $"*** Error: could not parse structured NL output for task '{task.TaskId}': {e.Message}"
+        };
+      }
+
+      return new NaturalLanguageTaskRequestResult {
+        Success = true,
+        OpenAiResponseId = openAiResponse.Id ?? "",
+        Response = new NaturalLanguageTaskResponse {
+          TaskId = task.TaskId,
+          Replacements = taskResponsePayload.Replacements ?? []
+        }
+      };
+    }
+
+    private static OpenAiResponsesRequest CreateOpenAiResponsesRequest(
+      string programName,
+      NaturalLanguageTask task,
+      string prompt,
+      int attempt,
+      string previousResponseId) {
+      var model = Environment.GetEnvironmentVariable("DAFNY_NL_OPENAI_MODEL");
+      if (string.IsNullOrWhiteSpace(model)) {
+        model = "gpt-5.4";
+      }
+
+      return new OpenAiResponsesRequest {
+        Model = model,
+        PreviousResponseId = string.IsNullOrWhiteSpace(previousResponseId) ? null : previousResponseId,
+        Input = prompt,
+        Metadata = new Dictionary<string, string> {
+          ["program_name"] = programName,
+          ["task_id"] = task.TaskId,
+          ["callable_name"] = task.CallableName,
+          ["attempt"] = attempt.ToString()
+        },
+        Text = new OpenAiResponsesTextConfiguration {
+          Format = new OpenAiResponsesJsonSchemaFormat {
+            Type = "json_schema",
+            Name = "dafny_nl_replacements",
+            Strict = true,
+            Schema = CreateNaturalLanguageResponseSchema()
+          }
+        }
+      };
+    }
+
+    private static object CreateNaturalLanguageResponseSchema() {
+      return new Dictionary<string, object> {
+        ["type"] = "object",
+        ["additionalProperties"] = false,
+        ["properties"] = new Dictionary<string, object> {
+          ["replacements"] = new Dictionary<string, object> {
+            ["type"] = "array",
+            ["items"] = new Dictionary<string, object> {
+              ["type"] = "object",
+              ["additionalProperties"] = false,
+              ["properties"] = new Dictionary<string, object> {
+                ["elementId"] = new Dictionary<string, object> { ["type"] = "string" },
+                ["code"] = new Dictionary<string, object> { ["type"] = "string" }
+              },
+              ["required"] = new[] { "elementId", "code" }
+            }
+          }
+        },
+        ["required"] = new[] { "replacements" }
+      };
+    }
+
+    private static string ExtractStructuredOutputText(OpenAiResponsesApiResponse response, out string refusalText) {
+      refusalText = "";
+      if (!string.IsNullOrWhiteSpace(response.OutputText)) {
+        return response.OutputText;
+      }
+
+      foreach (var outputItem in response.Output) {
+        foreach (var contentItem in outputItem.Content) {
+          if (!string.IsNullOrWhiteSpace(contentItem.Refusal)) {
+            refusalText = contentItem.Refusal;
+            return "";
+          }
+          if (!string.IsNullOrWhiteSpace(contentItem.Text)) {
+            return contentItem.Text;
+          }
+        }
+      }
+
+      return "";
+    }
+
+    private async Task<(bool Verified, Program Program, NaturalLanguageFeedbackByTask Feedback)> VerifyCandidateFilesAsync(
+      IReadOnlyList<DafnyFile> files,
+      DafnyOptions options,
+      IReadOnlyList<NaturalLanguageTask> tasks,
+      IReadOnlyDictionary<string, string> sourcePathMap) {
+      var fileNames = DafnyFile.FileNames(files);
+      var programName = fileNames.Count == 1 ? fileNames[0] : "the_program";
+      var (program, err) = await DafnyMain.ParseCheck(options.Input, files, programName, options);
+      var feedbackTasks = program == null
+        ? tasks.ToList()
+        : BuildNaturalLanguageFeedbackTasks(program, tasks, sourcePathMap);
+      if (feedbackTasks.Count == 0) {
+        feedbackTasks = tasks.ToList();
+      }
+      if (err != null || program == null) {
+        return (false, program, CollectFeedbackByTask(program, err ?? "Parse/resolve failed.", feedbackTasks, sourcePathMap));
+      }
+
+      if (!options.DafnyVerify) {
+        return (true, program, new NaturalLanguageFeedbackByTask());
+      }
+
+      var printer = options.Printer as DafnyConsolePrinter;
+      var verificationSnapshot = SnapshotVerificationResults(printer);
+      var boogiePrograms =
+        await DafnyMain.LargeStackFactory.StartNew(() => Translate(engine.Options, program).ToList());
+      var baseName = Cce.NonNull(Path.GetFileName(fileNames[^1]));
+      var (verified, _, _) = await BoogieAsync(program.Reporter, options, baseName, boogiePrograms, null);
+      if (verified) {
+        return (true, program, new NaturalLanguageFeedbackByTask());
+      }
+
+      var feedback = CollectFeedbackByTask(program, null, feedbackTasks, sourcePathMap);
+      MergeFeedback(feedback, CollectVerificationFeedbackFromResults(
+        GetNewVerificationResults(printer, verificationSnapshot), options, feedbackTasks, sourcePathMap));
+      if (feedback.FeedbackByTaskId.Count == 0 && feedback.GlobalFeedback.Count == 0) {
+        AddUnique(feedback.GlobalFeedback, new NaturalLanguageFailureContext { PrimaryMessage = "Verification failed." });
+      }
+      return (false, program, feedback);
+    }
+
+    private static Dictionary<Uri, string> LoadSourceTextsForRootFiles(
+      IReadOnlyList<DafnyFile> files, DafnyOptions options) {
+      var result = new Dictionary<Uri, string>();
+      foreach (var file in files.Where(f => f.Uri.IsFile && f.Extension == DafnyFile.DafnyFileExtension)) {
+        try {
+          result[file.Uri] = File.ReadAllText(file.Uri.LocalPath);
+        } catch (Exception e) {
+          throw new Exception($"Cannot read source file '{options.GetPrintPath(file.Uri.LocalPath)}': {e.Message}");
+        }
+      }
+      return result;
+    }
+
+    private static List<NaturalLanguageTask> BuildNaturalLanguageTasks(Program program,
+      IReadOnlyDictionary<Uri, string> sourceTexts) {
+      var tasks = new List<NaturalLanguageTask>();
+      foreach (var callable in ModuleDefinition.AllCallablesIncludingPrefixDeclarations(program.DefaultModuleDef.TopLevelDecls)) {
+        if (!TryGetSourceTextForUri(sourceTexts, callable.StartToken.Uri, out var uri, out var sourceText)) {
+          continue;
+        }
+
+        var collector = new NaturalLanguageCollector();
+        collector.Visit(callable, 0);
+        if (collector.Elements.Count == 0) {
+          continue;
+        }
+
+        NormalizeStatementReplacementRanges(collector.Elements, sourceText);
+
+        var callableName = callable switch {
+          MemberDecl member => member.FullDafnyName,
+          TopLevelDecl topLevel => topLevel.FullDafnyName,
+          _ => callable.NameRelativeToModule
+        };
+
+        var callableStart = callable.StartToken.pos;
+        var callableEnd = callable.EndToken.pos + callable.EndToken.val.Length;
+        var callableSource = SafeSlice(sourceText, callableStart, callableEnd);
+
+        tasks.Add(new NaturalLanguageTask {
+          TaskId = $"{callableName}@{callable.StartToken.line}:{callable.StartToken.col}",
+          CallableName = callableName,
+          CallableKind = callable switch {
+            Function function => function.WhatKind,
+            MethodOrConstructor methodOrConstructor => methodOrConstructor.WhatKind,
+            _ => "callable"
+          },
+          FileUri = uri,
+          FilePath = uri.LocalPath,
+          CallableStartPos = callableStart,
+          CallableEndPosExclusive = callableEnd,
+          CallableSource = callableSource,
+          Elements = collector.Elements
+        });
+      }
+
+      return tasks;
+    }
+
+    private static IReadOnlyList<NaturalLanguageSupportDeclaration> CollectRelevantSupportDeclarations(
+      Program program,
+      IReadOnlyDictionary<Uri, string> sourceTexts) {
+      var declarations = new List<NaturalLanguageSupportDeclaration>();
+      foreach (var callable in ModuleDefinition.AllCallablesIncludingPrefixDeclarations(program.DefaultModuleDef.TopLevelDecls)) {
+        if (callable is not Function function) {
+          continue;
+        }
+        if (!TryGetSourceTextForUri(sourceTexts, callable.StartToken.Uri, out var _, out var sourceText)) {
+          continue;
+        }
+
+        var declarationName = function.FullDafnyName;
+        var declarationStart = function.StartToken.pos;
+        var declarationEnd = function.EndToken.pos + function.EndToken.val.Length;
+        var declarationSource = SafeSlice(sourceText, declarationStart, declarationEnd);
+        if (string.IsNullOrWhiteSpace(declarationSource)) {
+          continue;
+        }
+
+        declarations.Add(new NaturalLanguageSupportDeclaration {
+          DeclarationName = declarationName,
+          DeclarationKind = function.WhatKind,
+          Source = declarationSource
+        });
+      }
+
+      return declarations;
+    }
+
+    private static string BuildNaturalLanguagePrompt(
+      NaturalLanguageTask task,
+      IReadOnlyList<NaturalLanguageSupportDeclaration> supportDeclarations,
+      IReadOnlyList<NaturalLanguageRetryHistoryEntry> retryHistory) {
+      var prompt = new StringBuilder();
+      prompt.AppendLine("You are generating Dafny code to replace natural-language placeholders inside one callable.");
+      prompt.AppendLine();
+      prompt.AppendLine($"Callable: {task.CallableName}");
+      prompt.AppendLine($"Kind: {task.CallableKind}");
+      prompt.AppendLine($"TaskId: {task.TaskId}");
+      prompt.AppendLine();
+      prompt.AppendLine("Callable source:");
+      prompt.AppendLine("```dafny");
+      prompt.AppendLine(task.CallableSource);
+      prompt.AppendLine("```");
+      prompt.AppendLine();
+      prompt.AppendLine("Natural-language placeholders to replace:");
+      foreach (var element in task.Elements) {
+        prompt.AppendLine($"- {element.ElementId}: kind={element.Kind}, inferredType={element.InferredType}, line={element.Line}, column={element.Column}");
+        prompt.AppendLine($"  Raw content: {element.RawContent}");
+      }
+
+      var usableDeclarations = supportDeclarations
+        .Where(declaration => !string.Equals(declaration.DeclarationName, task.CallableName, StringComparison.Ordinal))
+        .ToList();
+      if (usableDeclarations.Count > 0) {
+        prompt.AppendLine();
+        prompt.AppendLine("Available predicates and functions you may use:");
+        foreach (var declaration in usableDeclarations) {
+          prompt.AppendLine($"- {declaration.DeclarationKind} {declaration.DeclarationName}");
+          prompt.AppendLine("```dafny");
+          prompt.AppendLine(declaration.Source);
+          prompt.AppendLine("```");
+        }
+      }
+
+      if (retryHistory.Count > 0) {
+        prompt.AppendLine();
+        prompt.AppendLine("Cumulative retry history for this callable:");
+        foreach (var historyEntry in retryHistory.OrderBy(entry => entry.Attempt)) {
+          prompt.AppendLine($"Attempt {historyEntry.Attempt} replacements:");
+          foreach (var replacement in historyEntry.Replacements.OrderBy(replacement => replacement.ElementId)) {
+            if ((replacement.Code ?? "").Contains('\n') || (replacement.Code ?? "").Contains('\r')) {
+              prompt.AppendLine($"- {replacement.ElementId}:");
+              prompt.AppendLine("```dafny");
+              prompt.AppendLine(replacement.Code);
+              prompt.AppendLine("```");
+            } else {
+              prompt.AppendLine($"- {replacement.ElementId}: {replacement.Code}");
+            }
+          }
+          prompt.AppendLine("Feedback after that attempt:");
+          foreach (var failure in historyEntry.Failures) {
+            if (string.IsNullOrWhiteSpace(failure.PrimaryMessage)) {
+              continue;
+            }
+            prompt.AppendLine("```text");
+            prompt.AppendLine(failure.PrimaryMessage.TrimEnd());
+            prompt.AppendLine("```");
+          }
+          if (historyEntry.OmittedFailureCount > 0) {
+            prompt.AppendLine($"- {historyEntry.OmittedFailureCount} additional diagnostic(s) omitted.");
+          }
+        }
+      }
+
+      prompt.AppendLine();
+      prompt.AppendLine("Requirements:");
+      prompt.AppendLine("- Return replacement code for every ElementId in this callable.");
+      prompt.AppendLine("- For expression placeholders, return only a Dafny expression.");
+      prompt.AppendLine("- For statement placeholders, return Dafny statements that replace the placeholder statement.");
+      prompt.AppendLine("- Preserve surrounding specifications and verifier obligations.");
+      prompt.AppendLine("- Improve on every failed attempt using the cumulative retry history above.");
+      prompt.AppendLine("- Do not return markdown fences or explanations.");
+      prompt.AppendLine("- The transport response should map each ElementId to replacement code.");
+      return prompt.ToString();
+    }
+
+    private static bool TryGetSourceTextForUri(
+      IReadOnlyDictionary<Uri, string> sourceTexts,
+      Uri uri,
+      out Uri matchedUri,
+      out string sourceText) {
+      matchedUri = null;
+      sourceText = "";
+      if (uri == null || !uri.IsFile) {
+        return false;
+      }
+      if (sourceTexts.TryGetValue(uri, out sourceText)) {
+        matchedUri = uri;
+        return true;
+      }
+
+      var normalizedPath = Path.GetFullPath(uri.LocalPath);
+      var alternate = sourceTexts.FirstOrDefault(entry =>
+        entry.Key.IsFile && string.Equals(Path.GetFullPath(entry.Key.LocalPath), normalizedPath,
+          StringComparison.OrdinalIgnoreCase));
+      if (alternate.Key == null) {
+        return false;
+      }
+
+      matchedUri = alternate.Key;
+      sourceText = alternate.Value;
+      return true;
+    }
+
+    private static void NormalizeStatementReplacementRanges(
+      IReadOnlyList<NaturalLanguageElement> elements,
+      string sourceText) {
+      foreach (var element in elements.Where(element => element.Kind == "statement")) {
+        if (element.EndPosExclusive < sourceText.Length && sourceText[element.EndPosExclusive] == ';') {
+          element.EndPosExclusive++;
+        }
+      }
+    }
+
+    private static bool TryApplyNaturalLanguageResponses(
+      IReadOnlyList<NaturalLanguageTask> tasks,
+      IReadOnlyDictionary<Uri, string> originalSources,
+      NaturalLanguageResponseFile response,
+      out Dictionary<Uri, string> rewrittenSources,
+      out Dictionary<string, NaturalLanguageAppliedTaskContext> appliedTaskContexts,
+      out string error) {
+      rewrittenSources = originalSources.ToDictionary(kv => kv.Key, kv => kv.Value);
+      appliedTaskContexts = new Dictionary<string, NaturalLanguageAppliedTaskContext>(StringComparer.Ordinal);
+      var replacementsByFile = new Dictionary<Uri, List<TextReplacement>>();
+      var appliedReplacementsByTaskId = new Dictionary<string, List<NaturalLanguageAppliedReplacement>>(StringComparer.Ordinal);
+      var responseByTask = response.Tasks.ToDictionary(task => task.TaskId, task => task);
+
+      foreach (var task in tasks) {
+        if (!responseByTask.TryGetValue(task.TaskId, out var taskResponse)) {
+          error = $"missing response for task '{task.TaskId}'";
+          return false;
+        }
+
+        var replacementsById = taskResponse.Replacements.ToDictionary(replacement => replacement.ElementId, replacement => replacement);
+        foreach (var element in task.Elements) {
+          if (!replacementsById.TryGetValue(element.ElementId, out var replacement)) {
+            error = $"missing replacement for element '{element.ElementId}' in task '{task.TaskId}'";
+            return false;
+          }
+
+          var uri = new Uri(Path.GetFullPath(task.FilePath));
+          if (!replacementsByFile.TryGetValue(uri, out var replacementsForUri)) {
+            replacementsForUri = [];
+            replacementsByFile[uri] = replacementsForUri;
+          }
+          replacementsForUri.Add(new TextReplacement {
+            TaskId = task.TaskId,
+            ElementId = element.ElementId,
+            StartPos = element.StartPos,
+            EndPosExclusive = element.EndPosExclusive,
+            Code = replacement.Code ?? ""
+          });
+        }
+      }
+
+      foreach (var (uri, replacements) in replacementsByFile) {
+        if (!rewrittenSources.TryGetValue(uri, out var sourceText)) {
+          error = $"no source text available for '{uri.LocalPath}'";
+          return false;
+        }
+
+        var ordered = replacements
+          .OrderBy(replacement => replacement.StartPos)
+          .ThenBy(replacement => replacement.EndPosExclusive)
+          .ToList();
+        var rewritten = new StringBuilder(sourceText.Length);
+        var cursor = 0;
+        foreach (var replacement in ordered) {
+          if (replacement.StartPos < 0 || replacement.EndPosExclusive < replacement.StartPos || replacement.EndPosExclusive > sourceText.Length) {
+            error = $"invalid replacement range [{replacement.StartPos}, {replacement.EndPosExclusive}) in '{uri.LocalPath}'";
+            return false;
+          }
+          if (replacement.StartPos < cursor) {
+            error = $"overlapping replacement range [{replacement.StartPos}, {replacement.EndPosExclusive}) in '{uri.LocalPath}'";
+            return false;
+          }
+
+          rewritten.Append(sourceText, cursor, replacement.StartPos - cursor);
+          var insertedStart = rewritten.Length;
+          rewritten.Append(replacement.Code);
+          var insertedEnd = rewritten.Length;
+          cursor = replacement.EndPosExclusive;
+
+          if (!appliedReplacementsByTaskId.TryGetValue(replacement.TaskId, out var appliedReplacements)) {
+            appliedReplacements = [];
+            appliedReplacementsByTaskId[replacement.TaskId] = appliedReplacements;
+          }
+          appliedReplacements.Add(new NaturalLanguageAppliedReplacement {
+            ElementId = replacement.ElementId,
+            RewrittenStartPos = insertedStart,
+            RewrittenEndPosExclusive = insertedEnd
+          });
+        }
+        rewritten.Append(sourceText, cursor, sourceText.Length - cursor);
+
+        var rewrittenText = rewritten.ToString();
+        rewrittenSources[uri] = rewrittenText;
+
+        foreach (var task in tasks.Where(task => string.Equals(NormalizeFilePath(task.FilePath), NormalizeFilePath(uri.LocalPath), StringComparison.OrdinalIgnoreCase))) {
+          var rewrittenCallableStart = AdjustPositionThroughReplacements(task.CallableStartPos, ordered);
+          var rewrittenCallableEnd = AdjustPositionThroughReplacements(task.CallableEndPosExclusive, ordered);
+          appliedTaskContexts[task.TaskId] = new NaturalLanguageAppliedTaskContext {
+            TaskId = task.TaskId,
+            FilePath = NormalizeFilePath(uri.LocalPath),
+            CallableStartPos = rewrittenCallableStart,
+            CallableEndPosExclusive = rewrittenCallableEnd,
+            CallableStartLine = GetLineNumberAtPosition(rewrittenText, rewrittenCallableStart),
+            CallableSource = SafeSlice(rewrittenText, rewrittenCallableStart, rewrittenCallableEnd),
+            Replacements = appliedReplacementsByTaskId.TryGetValue(task.TaskId, out var appliedReplacements)
+              ? appliedReplacements.OrderBy(replacement => replacement.RewrittenStartPos).ToList()
+              : []
+          };
+        }
+      }
+
+      error = "";
+      return true;
+    }
+
+    private static List<NaturalLanguageTask> BuildNaturalLanguageFeedbackTasks(
+      Program program,
+      IReadOnlyList<NaturalLanguageTask> tasks,
+      IReadOnlyDictionary<string, string> sourcePathMap) {
+      var tasksByOriginalPathAndCallable = tasks
+        .GroupBy(task => (NormalizeFilePath(task.FilePath), task.CallableName))
+        .ToDictionary(
+          group => group.Key,
+          group => new Queue<NaturalLanguageTask>(group.OrderBy(task => task.CallableStartPos)));
+
+      var result = new List<NaturalLanguageTask>();
+      foreach (var callable in ModuleDefinition.AllCallablesIncludingPrefixDeclarations(program.DefaultModuleDef.TopLevelDecls)) {
+        if (callable.StartToken.Uri == null || !callable.StartToken.Uri.IsFile) {
+          continue;
+        }
+
+        var callableName = callable switch {
+          MemberDecl member => member.FullDafnyName,
+          TopLevelDecl topLevel => topLevel.FullDafnyName,
+          _ => callable.NameRelativeToModule
+        };
+        var originalPath = ResolveOriginalTaskFilePath(callable.StartToken.Uri.LocalPath, sourcePathMap);
+        if (!tasksByOriginalPathAndCallable.TryGetValue((originalPath, callableName), out var matchingTasks) || matchingTasks.Count == 0) {
+          continue;
+        }
+
+        var matchingTask = matchingTasks.Dequeue();
+        result.Add(new NaturalLanguageTask {
+          TaskId = matchingTask.TaskId,
+          CallableName = matchingTask.CallableName,
+          FileUri = callable.StartToken.Uri,
+          FilePath = callable.StartToken.Uri.LocalPath,
+          CallableStartPos = callable.StartToken.pos,
+          CallableEndPosExclusive = callable.EndToken.pos + callable.EndToken.val.Length
+        });
+      }
+
+      return result;
+    }
+
+    private static Dictionary<Uri, string> WriteRewrittenSources(
+      IReadOnlyList<DafnyFile> originalFiles,
+      IReadOnlyDictionary<Uri, string> rewrittenSources,
+      string suffix,
+      string outputDirectoryOverride = null) {
+      var result = new Dictionary<Uri, string>();
+      foreach (var original in originalFiles.Where(file => file.Uri.IsFile && file.Extension == DafnyFile.DafnyFileExtension)) {
+        if (!rewrittenSources.TryGetValue(original.Uri, out var rewrittenText)) {
+          continue;
+        }
+
+        var originalPath = original.Uri.LocalPath;
+        var outputDirectory = outputDirectoryOverride ?? Path.GetDirectoryName(originalPath) ?? ".";
+        Directory.CreateDirectory(outputDirectory);
+        var rewrittenPath = Path.Combine(
+          outputDirectory,
+          Path.GetFileNameWithoutExtension(originalPath) + suffix + DafnyFile.DafnyFileExtension);
+
+        File.WriteAllText(rewrittenPath, rewrittenText);
+        result[original.Uri] = rewrittenPath;
+      }
+
+      return result;
+    }
+
+    private static Dictionary<string, string> BuildNaturalLanguageSourcePathMap(
+      IReadOnlyDictionary<Uri, string> rewrittenPathsByOriginalUri) {
+      var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+      foreach (var (originalUri, rewrittenPath) in rewrittenPathsByOriginalUri) {
+        if (!originalUri.IsFile) {
+          continue;
+        }
+
+        result[NormalizeFilePath(rewrittenPath)] = NormalizeFilePath(originalUri.LocalPath);
+      }
+
+      return result;
+    }
+
+    private static void TryDeleteDirectory(string directoryPath) {
+      try {
+        if (Directory.Exists(directoryPath)) {
+          Directory.Delete(directoryPath, recursive: true);
+        }
+      } catch {
+        // Best-effort cleanup for temporary NL verification files.
+      }
+    }
+
+    private static List<DafnyFile> CreateDafnyFilesFromPaths(
+      IReadOnlyList<DafnyFile> originalFiles,
+      IReadOnlyDictionary<Uri, string> replacementPaths,
+      DafnyOptions options) {
+      var result = new List<DafnyFile>();
+      var reporter = new ConsoleErrorReporter(options);
+      foreach (var original in originalFiles) {
+        if (!original.Uri.IsFile || !replacementPaths.TryGetValue(original.Uri, out var replacementPath)) {
+          result.Add(original);
+          continue;
+        }
+
+        var replacementUri = new Uri(Path.GetFullPath(replacementPath));
+        var asLibrary = original.ShouldNotCompile && original.ShouldNotVerify;
+        var rewritten = DafnyFile.HandleDafnyFile(OnDiskFileSystem.Instance, reporter, options, replacementUri, Token.Cli, asLibrary);
+        if (rewritten == null) {
+          throw new Exception($"Failed to create DafnyFile for rewritten source '{replacementPath}'");
+        }
+
+        result.Add(rewritten);
+      }
+
+      return result;
+    }
+
+    private static string SafeSlice(string sourceText, int start, int endExclusive) {
+      if (start < 0 || endExclusive < start || endExclusive > sourceText.Length) {
+        return "";
+      }
+      return sourceText.Substring(start, endExclusive - start);
+    }
+
+    private static string SanitizeForPath(string value) {
+      var invalidCharacters = Path.GetInvalidFileNameChars();
+      var builder = new StringBuilder(value.Length);
+      foreach (var character in value) {
+        builder.Append(invalidCharacters.Contains(character) || character == ':' || character == '.' ? '_' : character);
+      }
+      return builder.ToString();
+    }
+
+    private static NaturalLanguageFeedbackByTask CollectFeedbackByTask(
+      Program program,
+      string fallbackError,
+      IReadOnlyList<NaturalLanguageTask> tasks,
+      IReadOnlyDictionary<string, string> sourcePathMap = null) {
+      var result = new NaturalLanguageFeedbackByTask();
+      if (program?.Reporter is BatchErrorReporter batchReporter) {
+        foreach (var diagnostic in batchReporter.AllMessages.Where(message => message.Level == ErrorLevel.Error)) {
+          var failure = CreateFailureContext(program.Options, diagnostic, sourcePathMap);
+          if (failure == null) {
+            continue;
+          }
+
+          var owner = tasks.FirstOrDefault(task =>
+            diagnostic.Range?.StartToken?.Uri != null &&
+            task.FileUri != null &&
+            task.FileUri.IsFile &&
+            string.Equals(
+              ResolveOriginalTaskFilePath(task.FileUri.LocalPath, sourcePathMap),
+              ResolveOriginalTaskFilePath(diagnostic.Range.StartToken.Uri.LocalPath, sourcePathMap),
+              StringComparison.OrdinalIgnoreCase) &&
+            diagnostic.Range.StartToken.pos >= task.CallableStartPos &&
+            diagnostic.Range.StartToken.pos < task.CallableEndPosExclusive);
+          if (owner == null) {
+            AddUnique(result.GlobalFeedback, failure);
+            continue;
+          }
+
+          if (!result.FeedbackByTaskId.TryGetValue(owner.TaskId, out var feedbackForTask)) {
+            feedbackForTask = [];
+            result.FeedbackByTaskId[owner.TaskId] = feedbackForTask;
+          }
+          AddUnique(feedbackForTask, failure);
+        }
+      }
+
+      if (result.FeedbackByTaskId.Count == 0 && result.GlobalFeedback.Count == 0 && fallbackError != null) {
+        AddUnique(result.GlobalFeedback, new NaturalLanguageFailureContext { PrimaryMessage = fallbackError });
+      }
+
+      return result;
+    }
+
+    private static List<DafnyConsolePrinter.ConsoleLogEntry> SnapshotVerificationResults(DafnyConsolePrinter printer) {
+      if (printer == null) {
+        return [];
+      }
+
+      return printer.VerificationResults.ToList();
+    }
+
+    private static IEnumerable<DafnyConsolePrinter.ConsoleLogEntry> GetNewVerificationResults(
+      DafnyConsolePrinter printer,
+      IReadOnlyList<DafnyConsolePrinter.ConsoleLogEntry> snapshot) {
+      if (printer == null) {
+        return Enumerable.Empty<DafnyConsolePrinter.ConsoleLogEntry>();
+      }
+
+      return printer.VerificationResults.Where(entry => !snapshot.Any(existing => ReferenceEquals(existing, entry)));
+    }
+
+    private static NaturalLanguageFeedbackByTask CollectVerificationFeedbackFromResults(
+      IEnumerable<DafnyConsolePrinter.ConsoleLogEntry> verificationResults,
+      DafnyOptions options,
+      IReadOnlyList<NaturalLanguageTask> tasks,
+      IReadOnlyDictionary<string, string> sourcePathMap) {
+      var result = new NaturalLanguageFeedbackByTask();
+      foreach (var verificationResult in verificationResults) {
+        var hadDetailedFeedback = false;
+        foreach (var counterexample in verificationResult.Result.Counterexamples ?? []) {
+          if (!TryGetCounterexampleFeedback(counterexample, out var token, out var message)) {
+            continue;
+          }
+
+          hadDetailedFeedback = true;
+          AddFeedbackForToken(result, tasks, token, CreateFailureContext(options, token, message, sourcePathMap), sourcePathMap);
+        }
+
+        if (!hadDetailedFeedback &&
+            TryDescribeVerificationOutcome(verificationResult, out var outcomeToken, out var outcomeMessage)) {
+          AddFeedbackForToken(result, tasks, outcomeToken, CreateFailureContext(options, outcomeToken, outcomeMessage, sourcePathMap), sourcePathMap);
+        }
+      }
+
+      return result;
+    }
+
+    private static bool TryGetCounterexampleFeedback(Counterexample counterexample, out IToken token, out string message) {
+      switch (counterexample) {
+        case CallCounterexample callCounterexample:
+          token = callCounterexample.FailingCall.tok;
+          message = callCounterexample.FailingCall.Description.FailureDescription;
+          return true;
+        case ReturnCounterexample returnCounterexample:
+          token = returnCounterexample.FailingReturn.tok;
+          message = returnCounterexample.FailingReturn.Description.FailureDescription;
+          return true;
+        case AssertCounterexample assertCounterexample:
+          token = assertCounterexample.FailingAssert.tok;
+          message = assertCounterexample.FailingAssert.ErrorMessage ??
+            assertCounterexample.FailingAssert.Description.FailureDescription;
+          return true;
+        default:
+          token = null;
+          message = "";
+          return false;
+      }
+    }
+
+    private static bool TryDescribeVerificationOutcome(
+      DafnyConsolePrinter.ConsoleLogEntry verificationResult,
+      out IToken token,
+      out string message) {
+      token = verificationResult.Implementation.Tok;
+      var implementationName = verificationResult.Implementation.Name;
+      switch (verificationResult.Result.Outcome) {
+        case VcOutcome.Errors:
+          message = $"Verification failed for '{implementationName}'.";
+          return true;
+        case VcOutcome.TimedOut:
+          message = $"Verification of '{implementationName}' timed out.";
+          return true;
+        case VcOutcome.OutOfResource:
+          message = $"Verification ran out of resources for '{implementationName}'.";
+          return true;
+        case VcOutcome.OutOfMemory:
+          message = $"Verification ran out of memory for '{implementationName}'.";
+          return true;
+        case VcOutcome.SolverException:
+          message = $"Verification encountered a solver exception for '{implementationName}'.";
+          return true;
+        case VcOutcome.Inconclusive:
+          message = $"Verification was inconclusive for '{implementationName}'.";
+          return true;
+        default:
+          message = "";
+          return false;
+      }
+    }
+
+    private static void AddFeedbackForToken(
+      NaturalLanguageFeedbackByTask feedback,
+      IReadOnlyList<NaturalLanguageTask> tasks,
+      IToken token,
+      NaturalLanguageFailureContext failure,
+      IReadOnlyDictionary<string, string> sourcePathMap) {
+      if (failure == null || string.IsNullOrWhiteSpace(failure.PrimaryMessage)) {
+        return;
+      }
+
+      var owner = FindTaskForToken(token, tasks, sourcePathMap);
+      if (owner == null) {
+        AddUnique(feedback.GlobalFeedback, failure);
+        return;
+      }
+
+      if (!feedback.FeedbackByTaskId.TryGetValue(owner.TaskId, out var taskFeedback)) {
+        taskFeedback = [];
+        feedback.FeedbackByTaskId[owner.TaskId] = taskFeedback;
+      }
+
+      AddUnique(taskFeedback, failure);
+    }
+
+    private static NaturalLanguageTask FindTaskForToken(
+      IToken token,
+      IReadOnlyList<NaturalLanguageTask> tasks,
+      IReadOnlyDictionary<string, string> sourcePathMap) {
+      if (token == null) {
+        return null;
+      }
+
+      var dafnyToken = BoogieGenerator.ToDafnyToken(token);
+      if (dafnyToken?.Uri == null || !dafnyToken.Uri.IsFile) {
+        return null;
+      }
+
+      var tokenPath = ResolveOriginalTaskFilePath(dafnyToken.Uri.LocalPath, sourcePathMap);
+      return tasks.FirstOrDefault(task =>
+        task.FileUri != null &&
+        task.FileUri.IsFile &&
+        string.Equals(ResolveOriginalTaskFilePath(task.FileUri.LocalPath, sourcePathMap), tokenPath, StringComparison.OrdinalIgnoreCase) &&
+        dafnyToken.pos >= task.CallableStartPos &&
+        dafnyToken.pos < task.CallableEndPosExclusive);
+    }
+
+    private static string ResolveOriginalTaskFilePath(
+      string filePath,
+      IReadOnlyDictionary<string, string> sourcePathMap) {
+      var normalizedPath = NormalizeFilePath(filePath);
+      if (sourcePathMap != null && sourcePathMap.TryGetValue(normalizedPath, out var originalPath)) {
+        return originalPath;
+      }
+
+      return normalizedPath;
+    }
+
+    private static string NormalizeFilePath(string filePath) {
+      return string.IsNullOrWhiteSpace(filePath) ? "" : Path.GetFullPath(filePath);
+    }
+
+    private static void MergeFeedback(NaturalLanguageFeedbackByTask target, NaturalLanguageFeedbackByTask source) {
+      foreach (var (taskId, feedback) in source.FeedbackByTaskId) {
+        if (!target.FeedbackByTaskId.TryGetValue(taskId, out var targetFeedback)) {
+          targetFeedback = [];
+          target.FeedbackByTaskId[taskId] = targetFeedback;
+        }
+
+        foreach (var failure in feedback) {
+          AddUnique(targetFeedback, failure);
+        }
+      }
+
+      foreach (var failure in source.GlobalFeedback) {
+        AddUnique(target.GlobalFeedback, failure);
+      }
+    }
+
+    private static void AddUnique(List<NaturalLanguageFailureContext> failures, NaturalLanguageFailureContext failure) {
+      if (failure == null) {
+        return;
+      }
+
+      if (!failures.Any(existing => FailureContextsMatch(existing, failure))) {
+        failures.Add(failure);
+      }
+    }
+
+    private static bool FailureContextsMatch(NaturalLanguageFailureContext left, NaturalLanguageFailureContext right) {
+      if (left == null || right == null) {
+        return false;
+      }
+
+      return string.Equals(left.PrimaryLocation, right.PrimaryLocation, StringComparison.Ordinal) &&
+             string.Equals(left.PrimaryMessage, right.PrimaryMessage, StringComparison.Ordinal) &&
+             string.Equals(left.PrimaryFilePath, right.PrimaryFilePath, StringComparison.OrdinalIgnoreCase) &&
+             left.PrimaryStartPos == right.PrimaryStartPos &&
+             left.PrimaryEndPosExclusive == right.PrimaryEndPosExclusive &&
+             string.Equals(left.Excerpt, right.Excerpt, StringComparison.Ordinal) &&
+             left.OverlappingElementIds.SequenceEqual(right.OverlappingElementIds) &&
+             RelatedFailureContextsMatch(left.RelatedMessages, right.RelatedMessages);
+    }
+
+    private static bool RelatedFailureContextsMatch(
+      IReadOnlyList<NaturalLanguageRelatedFailureContext> left,
+      IReadOnlyList<NaturalLanguageRelatedFailureContext> right) {
+      if (ReferenceEquals(left, right)) {
+        return true;
+      }
+      if (left == null || right == null || left.Count != right.Count) {
+        return false;
+      }
+
+      for (var i = 0; i < left.Count; i++) {
+        if (!string.Equals(left[i].Location, right[i].Location, StringComparison.Ordinal) ||
+            !string.Equals(left[i].Message, right[i].Message, StringComparison.Ordinal)) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    private static List<NaturalLanguageTask> SelectTasksToRequest(
+      int attempt,
+      IReadOnlyList<NaturalLanguageTask> tasks,
+      NaturalLanguageFeedbackByTask feedback,
+      IReadOnlyDictionary<string, NaturalLanguageTaskState> taskStates) {
+      if (attempt == 1) {
+        return tasks.ToList();
+      }
+
+      var failedTaskIds = feedback.FeedbackByTaskId.Keys.ToHashSet();
+      foreach (var task in tasks) {
+        if (!taskStates.TryGetValue(task.TaskId, out var taskState) || taskState.CurrentResponse == null) {
+          failedTaskIds.Add(task.TaskId);
+        }
+      }
+
+      if (failedTaskIds.Count == 0) {
+        if (feedback.GlobalFeedback.Count > 0) {
+          return tasks.ToList();
+        }
+        return [];
+      }
+
+      return tasks.Where(task => failedTaskIds.Contains(task.TaskId)).ToList();
+    }
+
+    private static bool TryBuildNaturalLanguageResponseFile(
+      IReadOnlyList<NaturalLanguageTask> tasks,
+      IReadOnlyDictionary<string, NaturalLanguageTaskState> taskStates,
+      out NaturalLanguageResponseFile response,
+      out string error) {
+      response = new NaturalLanguageResponseFile();
+      foreach (var task in tasks) {
+        if (!taskStates.TryGetValue(task.TaskId, out var taskState) || taskState.CurrentResponse == null) {
+          error = $"missing response for task '{task.TaskId}'";
+          return false;
+        }
+        response.Tasks.Add(taskState.CurrentResponse);
+      }
+
+      error = "";
+      return true;
+    }
+
+    private static void RecordRetryHistory(
+      int attempt,
+      NaturalLanguageFeedbackByTask feedback,
+      IReadOnlyList<NaturalLanguageTask> tasks,
+      IReadOnlyDictionary<string, NaturalLanguageTaskState> taskStates,
+      IReadOnlyDictionary<string, NaturalLanguageAppliedTaskContext> appliedTaskContexts) {
+      var feedbackTargets = feedback.FeedbackByTaskId.Keys.ToHashSet();
+      var applyGlobalFeedbackToAllTasks = feedbackTargets.Count == 0 && feedback.GlobalFeedback.Count > 0;
+
+      foreach (var task in tasks) {
+        if (!taskStates.TryGetValue(task.TaskId, out var taskState) || taskState.CurrentResponse == null) {
+          continue;
+        }
+
+        var combinedFeedback = new List<NaturalLanguageFailureContext>();
+        if (feedback.FeedbackByTaskId.TryGetValue(task.TaskId, out var taskFeedback)) {
+          foreach (var failure in taskFeedback) {
+            AddUnique(combinedFeedback, failure);
+          }
+        }
+        if (feedback.GlobalFeedback.Count > 0 && (applyGlobalFeedbackToAllTasks || combinedFeedback.Count > 0)) {
+          foreach (var failure in feedback.GlobalFeedback.Where(failure => ShouldIncludeGlobalFailureForTask(task.TaskId, failure, appliedTaskContexts))) {
+            AddUnique(combinedFeedback, failure);
+          }
+        }
+        if (combinedFeedback.Count == 0) {
+          continue;
+        }
+
+        var promptFailures = combinedFeedback
+          .Select(failure => CreatePromptFailureContext(task.TaskId, failure, appliedTaskContexts))
+          .OrderBy(failure => failure.PrimaryFilePath, StringComparer.OrdinalIgnoreCase)
+          .ThenBy(failure => failure.PrimaryStartPos)
+          .ThenBy(failure => failure.PrimaryMessage, StringComparer.Ordinal)
+          .ToList();
+        var retainedFailures = promptFailures.Take(3).ToList();
+
+        taskState.RetryHistory.Add(new NaturalLanguageRetryHistoryEntry {
+          Attempt = attempt,
+          Failures = retainedFailures,
+          OmittedFailureCount = Math.Max(0, promptFailures.Count - retainedFailures.Count),
+          Replacements = taskState.CurrentResponse.Replacements
+            .Select(replacement => new NaturalLanguageReplacementResponse {
+              ElementId = replacement.ElementId,
+              Code = replacement.Code
+            })
+            .ToList()
+        });
+      }
+    }
+
+    private static bool ShouldIncludeGlobalFailureForTask(
+      string taskId,
+      NaturalLanguageFailureContext failure,
+      IReadOnlyDictionary<string, NaturalLanguageAppliedTaskContext> appliedTaskContexts) {
+      if (failure == null) {
+        return false;
+      }
+      if (string.IsNullOrWhiteSpace(failure.PrimaryFilePath) || failure.PrimaryStartPos < 0) {
+        return true;
+      }
+      if (!appliedTaskContexts.TryGetValue(taskId, out var taskContext)) {
+        return true;
+      }
+
+      return string.Equals(NormalizeFilePath(taskContext.FilePath), failure.PrimaryFilePath, StringComparison.OrdinalIgnoreCase) &&
+             failure.PrimaryStartPos >= taskContext.CallableStartPos &&
+             failure.PrimaryStartPos < taskContext.CallableEndPosExclusive;
+    }
+
+    private static NaturalLanguageFailureContext CreatePromptFailureContext(
+      string taskId,
+      NaturalLanguageFailureContext failure,
+      IReadOnlyDictionary<string, NaturalLanguageAppliedTaskContext> appliedTaskContexts) {
+      return CloneFailureContext(failure);
+    }
+
+    private static NaturalLanguageFailureContext CloneFailureContext(NaturalLanguageFailureContext failure) {
+      if (failure == null) {
+        return null;
+      }
+
+      return new NaturalLanguageFailureContext {
+        PrimaryLocation = failure.PrimaryLocation,
+        PrimaryMessage = failure.PrimaryMessage,
+        PrimaryFilePath = failure.PrimaryFilePath,
+        PrimaryStartPos = failure.PrimaryStartPos,
+        PrimaryEndPosExclusive = failure.PrimaryEndPosExclusive,
+        Excerpt = failure.Excerpt,
+        RelatedMessages = failure.RelatedMessages
+          .Select(related => new NaturalLanguageRelatedFailureContext {
+            Location = related.Location,
+            Message = related.Message
+          })
+          .ToList(),
+        OverlappingElementIds = failure.OverlappingElementIds.ToList()
+      };
+    }
+
+    private static NaturalLanguageFailureContext CreateFailureContext(
+      DafnyOptions options,
+      DafnyDiagnostic diagnostic,
+      IReadOnlyDictionary<string, string> sourcePathMap) {
+      if (diagnostic == null) {
+        return null;
+      }
+
+      return new NaturalLanguageFailureContext {
+        PrimaryLocation = diagnostic.Range?.ToFileRangeString(options) ?? "",
+        PrimaryMessage = RenderDiagnosticBlock(options, diagnostic).TrimEnd(),
+        PrimaryFilePath = diagnostic.Range?.StartToken?.Uri != null && diagnostic.Range.StartToken.Uri.IsFile
+          ? ResolveOriginalTaskFilePath(diagnostic.Range.StartToken.Uri.LocalPath, sourcePathMap)
+          : (string.IsNullOrWhiteSpace(diagnostic.Range?.StartToken?.Filepath)
+            ? ""
+            : ResolveOriginalTaskFilePath(diagnostic.Range.StartToken.Filepath, sourcePathMap)),
+        PrimaryStartPos = diagnostic.Range?.StartToken?.pos ?? -1,
+        PrimaryEndPosExclusive = diagnostic.Range == null
+          ? -1
+          : diagnostic.Range.EndToken.pos + Math.Max(diagnostic.Range.EndLength, 1)
+      };
+    }
+
+    private static NaturalLanguageFailureContext CreateFailureContext(
+      DafnyOptions options,
+      IToken token,
+      string message,
+      IReadOnlyDictionary<string, string> sourcePathMap) {
+      if (string.IsNullOrWhiteSpace(message)) {
+        return null;
+      }
+
+      var dafnyToken = token == null ? null : BoogieGenerator.ToDafnyToken(token);
+      return new NaturalLanguageFailureContext {
+        PrimaryLocation = dafnyToken?.OriginToString(options) ?? "",
+        PrimaryMessage = RenderVerificationFeedbackBlock(options, token, message).TrimEnd(),
+        PrimaryFilePath = dafnyToken?.Uri != null && dafnyToken.Uri.IsFile
+          ? ResolveOriginalTaskFilePath(dafnyToken.Uri.LocalPath, sourcePathMap)
+          : (string.IsNullOrWhiteSpace(dafnyToken?.Filepath)
+            ? ""
+            : ResolveOriginalTaskFilePath(dafnyToken.Filepath, sourcePathMap)),
+        PrimaryStartPos = dafnyToken?.pos ?? -1,
+        PrimaryEndPosExclusive = dafnyToken == null
+          ? -1
+          : dafnyToken.pos + Math.Max(dafnyToken.val?.Length ?? 0, 1)
+      };
+    }
+
+    private static string RenderDiagnosticBlock(DafnyOptions options, DafnyDiagnostic diagnostic) {
+      var block = ErrorReporter.FormatDiagnostic(options, diagnostic).Replace("\n", "\n ");
+      if (options.Verbose && !string.IsNullOrEmpty(diagnostic.ErrorId) && diagnostic.ErrorId != "none") {
+        block += " (ID: " + diagnostic.ErrorId + ")\n";
+        var info = ErrorRegistry.GetDetail(diagnostic.ErrorId);
+        if (info != null) {
+          block += info;
+        }
+      } else {
+        block += "\n";
+      }
+
+      if (options.Get(Snippets.ShowSnippets) && diagnostic.Range.Uri != null) {
+        var tw = new StringWriter();
+        Snippets.WriteSourceCodeSnippet(options, diagnostic.Range, tw);
+        block += tw.ToString();
+      }
+
+      foreach (var related in diagnostic.RelatedInformation) {
+        var innerMessage = string.IsNullOrEmpty(related.Message)
+          ? "Related location"
+          : "Related location: " + related.Message;
+        block += $"{related.Range.ToFileRangeString(options)}: {innerMessage}\n";
+        if (options.Get(Snippets.ShowSnippets)) {
+          var tw = new StringWriter();
+          Snippets.WriteSourceCodeSnippet(options, related.Range, tw);
+          block += tw.ToString();
+        }
+      }
+
+      return block;
+    }
+
+    private static string RenderVerificationFeedbackBlock(DafnyOptions options, IToken token, string message) {
+      var printer = new DafnyConsolePrinter(options);
+      var writer = new StringWriter();
+      printer.ReportBplError(token, message, true, writer);
+      return writer.ToString();
+    }
+
+    private static string FormatFailureContextForPrompt(NaturalLanguageFailureContext failure) {
+      if (failure == null) {
+        return "";
+      }
+      if (string.IsNullOrWhiteSpace(failure.PrimaryLocation)) {
+        return failure.PrimaryMessage;
+      }
+      if (string.IsNullOrWhiteSpace(failure.PrimaryMessage)) {
+        return failure.PrimaryLocation;
+      }
+      return $"{failure.PrimaryLocation}: {failure.PrimaryMessage}";
+    }
+
+    private static string FormatRelatedFailureContextForPrompt(NaturalLanguageRelatedFailureContext related) {
+      if (related == null) {
+        return "";
+      }
+      if (string.IsNullOrWhiteSpace(related.Location)) {
+        return related.Message;
+      }
+      if (string.IsNullOrWhiteSpace(related.Message)) {
+        return related.Location;
+      }
+      return $"{related.Location}: {related.Message}";
+    }
+
+    private static List<string> FindOverlappingElementIds(
+      NaturalLanguageAppliedTaskContext taskContext,
+      NaturalLanguageFailureContext failure) {
+      if (taskContext == null || failure == null || string.IsNullOrWhiteSpace(failure.PrimaryFilePath) || failure.PrimaryStartPos < 0) {
+        return [];
+      }
+      if (!string.Equals(NormalizeFilePath(taskContext.FilePath), failure.PrimaryFilePath, StringComparison.OrdinalIgnoreCase)) {
+        return [];
+      }
+
+      var failureStart = failure.PrimaryStartPos;
+      var failureEnd = failure.PrimaryEndPosExclusive > failureStart ? failure.PrimaryEndPosExclusive : failureStart + 1;
+      return taskContext.Replacements
+        .Where(replacement => RangesOverlap(failureStart, failureEnd, replacement.RewrittenStartPos, replacement.RewrittenEndPosExclusive))
+        .Select(replacement => replacement.ElementId)
+        .OrderBy(elementId => elementId, StringComparer.Ordinal)
+        .ToList();
+    }
+
+    private static bool RangesOverlap(int start1, int end1, int start2, int end2) {
+      return start1 < end2 && start2 < end1;
+    }
+
+    private static string BuildFailureExcerpt(
+      NaturalLanguageAppliedTaskContext taskContext,
+      NaturalLanguageFailureContext failure) {
+      if (taskContext == null || failure == null || string.IsNullOrWhiteSpace(failure.PrimaryFilePath) ||
+          !string.Equals(NormalizeFilePath(taskContext.FilePath), failure.PrimaryFilePath, StringComparison.OrdinalIgnoreCase) ||
+          string.IsNullOrEmpty(taskContext.CallableSource)) {
+        return "";
+      }
+
+      var lines = new List<string>();
+      var lineStarts = new List<int>();
+      var lineStart = 0;
+      for (var i = 0; i < taskContext.CallableSource.Length; i++) {
+        if (taskContext.CallableSource[i] == '\r' || taskContext.CallableSource[i] == '\n') {
+          lines.Add(taskContext.CallableSource.Substring(lineStart, i - lineStart));
+          lineStarts.Add(lineStart);
+          if (taskContext.CallableSource[i] == '\r' && i + 1 < taskContext.CallableSource.Length && taskContext.CallableSource[i + 1] == '\n') {
+            i++;
+          }
+          lineStart = i + 1;
+        }
+      }
+      lines.Add(taskContext.CallableSource.Substring(lineStart));
+      lineStarts.Add(lineStart);
+
+      var failureLineIndex = -1;
+      var caretStart = 0;
+      var caretLength = 1;
+      if (failure.PrimaryStartPos >= taskContext.CallableStartPos &&
+          failure.PrimaryStartPos < taskContext.CallableEndPosExclusive) {
+        var localStart = failure.PrimaryStartPos - taskContext.CallableStartPos;
+        var localEnd = failure.PrimaryEndPosExclusive > failure.PrimaryStartPos
+          ? failure.PrimaryEndPosExclusive - taskContext.CallableStartPos
+          : localStart + 1;
+        if (localStart >= 0 && localStart < taskContext.CallableSource.Length) {
+          for (var i = 0; i < lineStarts.Count; i++) {
+            var nextLineStart = i + 1 < lineStarts.Count ? lineStarts[i + 1] : taskContext.CallableSource.Length + 1;
+            if (localStart < nextLineStart) {
+              failureLineIndex = i;
+              var lineStartOffset = lineStarts[i];
+              caretStart = Math.Max(0, Math.Min(lines[i].Length, localStart - lineStartOffset));
+              var maxEndInLine = lineStartOffset + lines[i].Length;
+              var caretEnd = Math.Max(caretStart + 1, Math.Min(Math.Max(localEnd, localStart + 1), maxEndInLine) - lineStartOffset);
+              caretLength = Math.Max(1, caretEnd - caretStart);
+              break;
+            }
+          }
+        }
+      }
+
+      if (failureLineIndex < 0 && TryParseLineAndColumnFromLocation(failure.PrimaryLocation, out var lineNumber, out var column)) {
+        var localLineIndex = lineNumber - taskContext.CallableStartLine;
+        if (0 <= localLineIndex && localLineIndex < lines.Count) {
+          failureLineIndex = localLineIndex;
+          caretStart = Math.Max(0, Math.Min(lines[localLineIndex].Length, column));
+          caretLength = 1;
+        }
+      }
+
+      if (failureLineIndex < 0) {
+        return "";
+      }
+
+      var excerptStartLine = Math.Max(0, failureLineIndex - 2);
+      var excerptEndLine = Math.Min(lines.Count - 1, failureLineIndex + 2);
+      var numberWidth = (taskContext.CallableStartLine + excerptEndLine).ToString().Length;
+      var builder = new StringBuilder();
+      for (var i = excerptStartLine; i <= excerptEndLine; i++) {
+        var displayedLineNumber = taskContext.CallableStartLine + i;
+        builder.AppendLine($"{displayedLineNumber.ToString().PadLeft(numberWidth)} | {lines[i]}");
+        if (i == failureLineIndex) {
+          builder.AppendLine($"{new string(' ', numberWidth)} | {new string(' ', caretStart)}{new string('^', caretLength)}");
+        }
+      }
+
+      return builder.ToString().TrimEnd();
+    }
+
+    private static bool TryParseLineAndColumnFromLocation(string location, out int line, out int column) {
+      line = 0;
+      column = 0;
+      if (string.IsNullOrWhiteSpace(location)) {
+        return false;
+      }
+
+      var match = Regex.Match(location, @"\((\d+)(?:,|:)(\d+)");
+      if (!match.Success) {
+        return false;
+      }
+
+      return int.TryParse(match.Groups[1].Value, out line) && int.TryParse(match.Groups[2].Value, out column);
+    }
+
+    private static int AdjustPositionThroughReplacements(int originalPosition, IReadOnlyList<TextReplacement> replacements) {
+      var adjustedPosition = originalPosition;
+      foreach (var replacement in replacements) {
+        if (replacement.EndPosExclusive <= originalPosition) {
+          adjustedPosition += replacement.Code.Length - (replacement.EndPosExclusive - replacement.StartPos);
+        }
+      }
+      return adjustedPosition;
+    }
+
+    private static int GetLineNumberAtPosition(string sourceText, int position) {
+      if (position <= 0 || string.IsNullOrEmpty(sourceText)) {
+        return 1;
+      }
+
+      var clampedPosition = Math.Min(position, sourceText.Length);
+      var line = 1;
+      for (var i = 0; i < clampedPosition; i++) {
+        if (sourceText[i] == '\n') {
+          line++;
+        }
+      }
+      return line;
+    }
+
+    private sealed class NaturalLanguageCollector : TopDownVisitor<int> {
+      private int nextId = 1;
+      public List<NaturalLanguageElement> Elements { get; } = [];
+
+      protected override bool VisitOneExpr(Expression expr, ref int state) {
+        if (expr is NaturalLanguageExpression naturalLanguageExpression) {
+          Elements.Add(new NaturalLanguageElement {
+            ElementId = $"nl{nextId++}",
+            Kind = "expression",
+            StartPos = naturalLanguageExpression.StartToken.pos,
+            EndPosExclusive = naturalLanguageExpression.EndToken.pos + naturalLanguageExpression.EndToken.val.Length,
+            RawContent = naturalLanguageExpression.RawContent,
+            InferredType = naturalLanguageExpression.Type?.ToString() ?? "<unknown>",
+            Line = naturalLanguageExpression.Origin.line,
+            Column = naturalLanguageExpression.Origin.col
+          });
+        }
+
+        return base.VisitOneExpr(expr, ref state);
+      }
+
+      protected override bool VisitOneStmt(Statement stmt, ref int state) {
+        if (stmt is NaturalLanguageStatement naturalLanguageStatement) {
+          Elements.Add(new NaturalLanguageElement {
+            ElementId = $"nl{nextId++}",
+            Kind = "statement",
+            StartPos = naturalLanguageStatement.StartToken.pos,
+            EndPosExclusive = naturalLanguageStatement.EndToken.pos + naturalLanguageStatement.EndToken.val.Length,
+            RawContent = naturalLanguageStatement.RawContent,
+            InferredType = "<statement>",
+            Line = naturalLanguageStatement.Origin.line,
+            Column = naturalLanguageStatement.Origin.col
+          });
+        }
+
+        return base.VisitOneStmt(stmt, ref state);
+      }
+    }
+
+    private sealed class NaturalLanguageTask {
+      public string TaskId { get; set; } = "";
+      public string CallableName { get; set; } = "";
+      public string CallableKind { get; set; } = "";
+      public Uri FileUri { get; set; }
+      public string FilePath { get; set; } = "";
+      public int CallableStartPos { get; set; }
+      public int CallableEndPosExclusive { get; set; }
+      public string CallableSource { get; set; } = "";
+      public List<NaturalLanguageElement> Elements { get; set; } = [];
+    }
+
+    private sealed class NaturalLanguageSupportDeclaration {
+      public string DeclarationName { get; set; } = "";
+      public string DeclarationKind { get; set; } = "";
+      public string Source { get; set; } = "";
+    }
+
+    private sealed class NaturalLanguageElement {
+      public string ElementId { get; set; } = "";
+      public string Kind { get; set; } = "";
+      public int StartPos { get; set; }
+      public int EndPosExclusive { get; set; }
+      public string RawContent { get; set; } = "";
+      public string InferredType { get; set; } = "";
+      public int Line { get; set; }
+      public int Column { get; set; }
+
+      public NaturalLanguageElementRequest ToRequest() {
+        return new NaturalLanguageElementRequest {
+          ElementId = ElementId,
+          Kind = Kind,
+          StartPos = StartPos,
+          EndPosExclusive = EndPosExclusive,
+          RawContent = RawContent,
+          InferredType = InferredType,
+          Line = Line,
+          Column = Column
+        };
+      }
+    }
+
+    private sealed class TextReplacement {
+      public string TaskId { get; set; } = "";
+      public string ElementId { get; set; } = "";
+      public int StartPos { get; set; }
+      public int EndPosExclusive { get; set; }
+      public string Code { get; set; } = "";
+    }
+
+    private sealed class NaturalLanguageAppliedReplacement {
+      public string ElementId { get; set; } = "";
+      public int RewrittenStartPos { get; set; }
+      public int RewrittenEndPosExclusive { get; set; }
+    }
+
+    private sealed class NaturalLanguageAppliedTaskContext {
+      public string TaskId { get; set; } = "";
+      public string FilePath { get; set; } = "";
+      public int CallableStartPos { get; set; }
+      public int CallableEndPosExclusive { get; set; }
+      public int CallableStartLine { get; set; }
+      public string CallableSource { get; set; } = "";
+      public List<NaturalLanguageAppliedReplacement> Replacements { get; set; } = [];
+    }
+
+    private sealed class NaturalLanguageFailureContext {
+      public string PrimaryLocation { get; set; } = "";
+      public string PrimaryMessage { get; set; } = "";
+      public string PrimaryFilePath { get; set; } = "";
+      public int PrimaryStartPos { get; set; } = -1;
+      public int PrimaryEndPosExclusive { get; set; } = -1;
+      public List<NaturalLanguageRelatedFailureContext> RelatedMessages { get; set; } = [];
+      public string Excerpt { get; set; } = "";
+      public List<string> OverlappingElementIds { get; set; } = [];
+    }
+
+    private sealed class NaturalLanguageRelatedFailureContext {
+      public string Location { get; set; } = "";
+      public string Message { get; set; } = "";
+    }
+
+    private sealed class NaturalLanguagePromptRequest {
+      public int Version { get; set; }
+      public int Attempt { get; set; }
+      public string ProgramName { get; set; } = "";
+      public string TaskId { get; set; } = "";
+      public string CallableName { get; set; } = "";
+      public string CallableKind { get; set; } = "";
+      public string Prompt { get; set; } = "";
+      public List<NaturalLanguageElementRequest> Elements { get; set; } = [];
+      public List<string> RelevantFeedback { get; set; } = [];
+    }
+
+    private sealed class NaturalLanguageElementRequest {
+      public string ElementId { get; set; } = "";
+      public string Kind { get; set; } = "";
+      public int StartPos { get; set; }
+      public int EndPosExclusive { get; set; }
+      public string RawContent { get; set; } = "";
+      public string InferredType { get; set; } = "";
+      public int Line { get; set; }
+      public int Column { get; set; }
+    }
+
+    private sealed class NaturalLanguageResponseFile {
+      public List<NaturalLanguageTaskResponse> Tasks { get; set; } = [];
+    }
+
+    private sealed class NaturalLanguageTaskResponseFile {
+      public string TaskId { get; set; } = "";
+      public List<NaturalLanguageReplacementResponse> Replacements { get; set; } = [];
+    }
+
+    private sealed class NaturalLanguageTaskResponse {
+      public string TaskId { get; set; } = "";
+      public List<NaturalLanguageReplacementResponse> Replacements { get; set; } = [];
+    }
+
+    private sealed class NaturalLanguageTaskRequestResult {
+      public bool Success { get; set; }
+      public string ErrorMessage { get; set; } = "";
+      public string OpenAiResponseId { get; set; } = "";
+      public NaturalLanguageTaskResponse Response { get; set; } = new();
+    }
+
+    private sealed class NaturalLanguageFeedbackByTask {
+      public Dictionary<string, List<NaturalLanguageFailureContext>> FeedbackByTaskId { get; } = [];
+      public List<NaturalLanguageFailureContext> GlobalFeedback { get; } = [];
+    }
+
+    private sealed class NaturalLanguageTaskState {
+      public string PreviousOpenAiResponseId { get; set; } = "";
+      public NaturalLanguageTaskResponse CurrentResponse { get; set; }
+      public List<NaturalLanguageRetryHistoryEntry> RetryHistory { get; } = [];
+    }
+
+    private sealed class NaturalLanguageRetryHistoryEntry {
+      public int Attempt { get; set; }
+      public List<NaturalLanguageFailureContext> Failures { get; set; } = [];
+      public int OmittedFailureCount { get; set; }
+      public List<NaturalLanguageReplacementResponse> Replacements { get; set; } = [];
+    }
+
+    private sealed class NaturalLanguageReplacementResponse {
+      public string ElementId { get; set; } = "";
+      public string Code { get; set; } = "";
+    }
+
+    private sealed class NaturalLanguageTaskResponsePayload {
+      public List<NaturalLanguageReplacementResponse> Replacements { get; set; } = [];
+    }
+
+    private sealed class OpenAiResponsesRequest {
+      [JsonPropertyName("model")]
+      public string Model { get; set; } = "";
+
+      [JsonPropertyName("previous_response_id")]
+      public string PreviousResponseId { get; set; }
+
+      [JsonPropertyName("input")]
+      public string Input { get; set; } = "";
+
+      [JsonPropertyName("metadata")]
+      public Dictionary<string, string> Metadata { get; set; } = [];
+
+      [JsonPropertyName("text")]
+      public OpenAiResponsesTextConfiguration Text { get; set; }
+    }
+
+    private sealed class OpenAiResponsesTextConfiguration {
+      [JsonPropertyName("format")]
+      public OpenAiResponsesJsonSchemaFormat Format { get; set; }
+    }
+
+    private sealed class OpenAiResponsesJsonSchemaFormat {
+      [JsonPropertyName("type")]
+      public string Type { get; set; } = "";
+
+      [JsonPropertyName("name")]
+      public string Name { get; set; } = "";
+
+      [JsonPropertyName("strict")]
+      public bool Strict { get; set; }
+
+      [JsonPropertyName("schema")]
+      public object Schema { get; set; }
+    }
+
+    private sealed class OpenAiResponsesApiResponse {
+      [JsonPropertyName("id")]
+      public string Id { get; set; } = "";
+
+      [JsonPropertyName("output_text")]
+      public string OutputText { get; set; } = "";
+
+      [JsonPropertyName("output")]
+      public List<OpenAiResponsesOutputItem> Output { get; set; } = [];
+    }
+
+    private sealed class OpenAiResponsesOutputItem {
+      [JsonPropertyName("content")]
+      public List<OpenAiResponsesContentItem> Content { get; set; } = [];
+    }
+
+    private sealed class OpenAiResponsesContentItem {
+      [JsonPropertyName("type")]
+      public string Type { get; set; } = "";
+
+      [JsonPropertyName("text")]
+      public string Text { get; set; } = "";
+
+      [JsonPropertyName("refusal")]
+      public string Refusal { get; set; } = "";
+    }
     /// <summary>
     /// Extract the counterexample corresponding to the first failing
     /// assertion and print it to the console

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny4/nl-blocks-expr-stmt.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny4/nl-blocks-expr-stmt.dfy.expect
@@ -1,4 +1,1 @@
-nl-blocks-expr-stmt.dfy(6,11): Warning: Natural-language blocks are parsed experimentally, but semantics are not supported yet
-nl-blocks-expr-stmt.dfy(10,4): Warning: Natural-language blocks are parsed experimentally, but semantics are not supported yet
-
 Dafny program verifier did not attempt verification

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny4/nl-blocks-type-inference.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny4/nl-blocks-type-inference.dfy.expect
@@ -1,7 +1,2 @@
-nl-blocks-type-inference.dfy(6,19): Warning: Natural-language blocks are parsed experimentally, but semantics are not supported yet
-nl-blocks-type-inference.dfy(7,18): Warning: Natural-language blocks are parsed experimentally, but semantics are not supported yet
-nl-blocks-type-inference.dfy(8,16): Warning: Natural-language blocks are parsed experimentally, but semantics are not supported yet
-nl-blocks-type-inference.dfy(13,11): Warning: Natural-language blocks are parsed experimentally, but semantics are not supported yet
-nl-blocks-type-inference.dfy(13,51): Warning: Natural-language blocks are parsed experimentally, but semantics are not supported yet
 nl-blocks-type-inference.dfy(13,11): Error: the type of this natural-language expression is underspecified
 1 resolution/type errors detected in nl-blocks-type-inference.dfy

--- a/docs/HowToFAQ/FAQNaturalLanguageBlocks.md
+++ b/docs/HowToFAQ/FAQNaturalLanguageBlocks.md
@@ -19,11 +19,34 @@ module {:options "--natural-language-blocks"} M {
 }
 ```
 
-Current behavior is intentionally placeholder-only:
+### Current behavior
 
 - Parsing is gated by `--natural-language-blocks`.
 - Without that option, parsing reports: `Natural-language blocks are supported only with --natural-language-blocks`.
-- Resolver emits a warning: `Natural-language blocks are parsed experimentally, but semantics are not supported yet`.
-- Verification and compilation continue with placeholder handling (`NaturalLanguageExpression` is treated as a placeholder value, and `NaturalLanguageStatement` is treated as a no-op).
+- For most source-processing commands, Dafny then runs the experimental natural-language expansion workflow before continuing with the requested command.
 
-This feature is experimental and its semantics are expected to change.
+### Expansion workflow
+
+When `--natural-language-blocks` is enabled for commands `verify` and `run`:
+
+- Dafny parses the original program and finds each method that still contains natural-language placeholders.
+- Dafny sends one request per method to either a configured endpoint (`DAFNY_NL_API_URL`) or the OpenAI Responses API when `OPENAI_API_KEY` is set and `DAFNY_NL_API_URL` is unset.
+- The endpoint returns concrete replacements for every placeholder in that method.
+- Dafny applies those replacements, re-runs parsing, resolution, and verification, and retries up to 10 times if needed. (For now this number is hard-coded, however, it is going to be customizable later.)
+- After the first attempt, Dafny re-requests only the methods that still fail.
+- On success, Dafny writes rewritten files with the `.nlgen.dfy` suffix and continues the requested command on those rewritten files.
+
+### Practical notes
+
+- The original source file is not overwritten.
+- In NL mode, later commands operate on the rewritten `.nlgen` program rather than on the original placeholders.
+- `--natural-language-blocks` does not support stdin input.
+
+### Inspecting intermediate artifacts
+
+If you pass `--natural-language-intermediate-products-directory <dir>`, Dafny writes artifacts such as:
+
+- `*.prompt.<callable>.attempt<N>.txt`: the human-readable prompt with real line breaks.
+- `*.task.<callable>.attempt<N>.json`: the exact JSON request body.
+- `*.response.<callable>.attempt<N>.json`: the saved API response.
+- `*.nlgen.attempt<N>.dfy`: the rewritten source used for that retry attempt.


### PR DESCRIPTION
### Expansion workflow

When `--natural-language-blocks` is enabled for commands `verify` or `run`:
- Dafny parses the original program and finds methods that contains natural-language expressions or blocks (hereinafter "NL syntax").
- Dafny sends one request per method to either a configured endpoint (`DAFNY_NL_API_URL`) or the OpenAI Responses API when `OPENAI_API_KEY` is set and `DAFNY_NL_API_URL` is unset.
- After the endpoint returns concrete replacements for every NL syntax in that method, Dafny applies those replacements, re-runs parsing, resolution, and verification, and retries up to 10 times if needed. *For now this number is hard-coded, however, it is going to be customizable later.*
- After the first attempt, Dafny re-requests only the methods that still fail.
- On success, Dafny writes rewritten files with the `.nlgen.dfy` suffix (The original source file is not overwritten.) and continues the requested command on those rewritten files.

### Inspecting intermediate products

If you pass `--natural-language-intermediate-products-directory <dir>`, Dafny emits intermediate products such as:

- `*.prompt.<callable>.attempt<N>.txt`: the human-readable prompt with real line breaks.
- `*.task.<callable>.attempt<N>.json`: the exact JSON request body.
- `*.response.<callable>.attempt<N>.json`: the saved API response.
- `*.nlgen.attempt<N>.dfy`: the rewritten source used for that retry attempt.

### A working example

Contents of `nl_demo.dfy`:
```dafny
datatype Option<+T> = None | Some(value: T)

ghost predicate Irreflexive<T(!new)>(relation: (T, T) -> bool) {
  forall x :: !relation(x, x)
}

ghost predicate AntiSymmetric<T(!new)>(relation: (T, T) -> bool) {
  forall x, y :: relation(x, y) && relation(y, x) ==> x == y
}

ghost predicate Transitive<T(!new)>(relation: (T, T) -> bool) {
  forall x, y, z :: relation(x, y) && relation(y, z) ==> relation(x, z)
}

ghost predicate Connected<T(!new)>(relation: (T, T) -> bool) {
  forall x, y :: x != y ==> relation(x, y) || relation(y, x)
}

ghost predicate StrictTotalOrdering<T(!new)>(relation: (T, T) -> bool) {
  && Irreflexive(relation)
  && AntiSymmetric(relation)
  && Transitive(relation)
  && Connected(relation)
}

ghost predicate SortedBy<T>(lessOrEqual: (T, T) -> bool, xs: seq<T>) {
  forall i, j | 0 <= i < j < |xs| :: lessOrEqual(xs[i], xs[j])
}

method BinarySearch<T(!new)>(a: array<T>, key: T, less: (T, T) -> bool) returns (r: Option<nat>)
  requires SortedBy((x, y) => less(x, y) || x == y, a[..])
  requires StrictTotalOrdering(less)
  ensures r.Some? ==> r.value < a.Length && a[r.value] == key
  ensures r.None? ==> key !in a[..]
{
  var lo, hi : nat := 0, a.Length;
  while lo < hi
    invariant `` key is not in the excluded range so far ``
    invariant `` Contents of the array a remains the same ``
    invariant `` lo and hi is in appropriate range ``
  {
    var mid := (lo + hi) / 2;
    `` If a[mid] is key then return, otherwise update lo or hi accordingly. ``;
  }

  return None;
}

function Fib(n: nat): nat {
  if n < 2 then n else Fib(n - 1) + Fib(n - 2)
}

method FibFast(n: nat) returns (r: nat)
  ensures r == Fib(n)
{
  if n == 0 {
    return 0;
  }

  var i := 1;
  var a := 0;
  var b := 1;
  while i < n
    invariant `` the loop state represents consecutive Fibonacci numbers at a valid unfinished position ``
  {
    `` Advance to the next Fibonacci state. ``;
  }

  return b;
}

method Main() {}
```

Usage:
```bash
export OPENAI_API_KEY=<key>
```
```bash
dotnet Binaries/Dafny.dll run --natural-language-blocks nl_demo.dfy --natural-language-intermediate-products-directory <dir>
```

### Misc.

Error messages during expansion workflow are not properly handled yet.